### PR TITLE
Zandara/isaac

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Github CI
 - `kuka_lbr_iisy_support` contains urdf, config and mesh files for KUKA iisy robots.
 - `kuka_lbr_iisy_moveit_config` contains configuration files for KUKA LBR iisy robots necessary for planning with MoveIt.
 - `kuka_agilus_support` contains urdf, config and mesh files for KUKA Agilus robots, it is copied from [kuka_experimental](https://github.com/ros-industrial/kuka_experimental) and ported to ROS2.
-- `kuka_lbr_iiwa_support` contains urdf, config and mesh files for KUKA LBR iiwa robots
+- `kuka_lbr_iiwa_support` contains urdf, config and mesh files for KUKA LBR iiwa robots.
 - `kuka_lbr_iiwa_moveit_config` contains configuration files for KUKA LBR iiwa robots necessary for planning with MoveIt.
 
 ## Structure of the support packages

--- a/kuka_agilus_support/urdf/kr10_r1100_2.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr10_r1100_2.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr10_r1100_2_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="enable_isaac_sim" default="false"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
   <xacro:arg name="prefix" default=""/>
@@ -13,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr10_r1100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_kr10_r1100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" enable_isaac_sim="$(arg enable_isaac_sim)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr10_r1100_2_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr10_r1100_2_macro.xacro
+++ b/kuka_agilus_support/urdf/kr10_r1100_2_macro.xacro
@@ -4,7 +4,7 @@
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
-  <xacro:macro name="kuka_kr10_r1100_2_robot" params="client_ip client_port prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_kr10_r1100_2_robot" params="client_ip client_port prefix use_fake_hardware enable_isaac_sim *origin">
     <!-- ros2 control instance -->
     <xacro:kuka_agilus_ros2_control name="${prefix}kr10_r1100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" enable_isaac_sim="${enable_isaac_sim}"/>
     <!-- links - main serial chain -->

--- a/kuka_agilus_support/urdf/kr10_r1100_2_macro.xacro
+++ b/kuka_agilus_support/urdf/kr10_r1100_2_macro.xacro
@@ -6,7 +6,7 @@
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:macro name="kuka_kr10_r1100_2_robot" params="client_ip client_port prefix use_fake_hardware *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr10_r1100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr10_r1100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" enable_isaac_sim="${enable_isaac_sim}"/>
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">

--- a/kuka_agilus_support/urdf/kr6_r700_sixx.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr6_r700_sixx.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr6_r700_sixx_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="enable_isaac_sim" default="false"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
   <xacro:arg name="prefix" default=""/>
@@ -13,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr6_r700_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_kr6_r700_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" enable_isaac_sim="$(arg enable_isaac_sim)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr6_r700_sixx_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
@@ -6,7 +6,7 @@
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
   <xacro:macro name="kuka_kr6_r700_sixx_robot" params="client_ip client_port prefix use_fake_hardware *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r700_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r700_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" enable_isaac_sim="${enable_isaac_sim}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <visual>

--- a/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
@@ -4,7 +4,7 @@
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
-  <xacro:macro name="kuka_kr6_r700_sixx_robot" params="client_ip client_port prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_kr6_r700_sixx_robot" params="client_ip client_port prefix use_fake_hardware enable_isaac_sim *origin">
     <!-- ros2 control instance -->
     <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r700_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" enable_isaac_sim="${enable_isaac_sim}"/>
     <link name="world"/>

--- a/kuka_agilus_support/urdf/kr6_r900_sixx.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr6_r900_sixx.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr6_r900_sixx_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="enable_isaac_sim" default="false"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
   <xacro:arg name="prefix" default=""/>
@@ -13,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr6_r900_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_kr6_r900_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" enable_isaac_sim="$(arg enable_isaac_sim)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr6_r900_sixx_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
@@ -6,7 +6,7 @@
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
   <xacro:macro name="kuka_kr6_r900_sixx_robot" params="client_ip client_port prefix use_fake_hardware *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r900_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r900_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" enable_isaac_sim="${enable_isaac_sim}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <visual>

--- a/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
@@ -4,7 +4,7 @@
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
-  <xacro:macro name="kuka_kr6_r900_sixx_robot" params="client_ip client_port prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_kr6_r900_sixx_robot" params="client_ip client_port prefix use_fake_hardware enable_isaac_sim *origin">
     <!-- ros2 control instance -->
     <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r900_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" enable_isaac_sim="${enable_isaac_sim}"/>
     <link name="world"/>

--- a/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
+++ b/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
@@ -4,9 +4,16 @@
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>mock_components/GenericSystem</plugin>
-          <param name="mock_sensor_commands">false</param>
-          <param name="state_following_offset">0.0</param>
+          <xacro:if value="${enable_isaac_sim}">
+            <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
+            <param name="joint_commands_topic">/joint_commands</param>
+            <param name="joint_states_topic">/joint_states</param>
+          </xacro:if>
+          <xacro:unless value="${enable_isaac_sim}">
+            <plugin>mock_components/GenericSystem</plugin>
+            <param name="mock_sensor_commands">false</param>
+            <param name="state_following_offset">0.0</param>
+          </xacro:unless>
         </xacro:if>
         <xacro:unless value="${use_fake_hardware}">
           <plugin>kuka_kss_rsi_driver::KukaRSIHardwareInterface</plugin>

--- a/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
+++ b/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_agilus_ros2_control" params="name client_ip client_port prefix use_fake_hardware">
+  <xacro:macro name="kuka_agilus_ros2_control" params="name client_ip client_port prefix use_fake_hardware enable_isaac_sim">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">


### PR DESCRIPTION
### Before submitting this PR into master please make sure:
If you added a new robot model:
- [ ] you extended the table of verified data in `README.md` with the new model
- [ ] you extended the CMakeLists.txt of the appropriate moveit configuration package with the new model
- [ ] you added a `test_<robot_model>.launch.py` and after launching the robot was visible in `rviz`
- [ ] you added a `<robot_model>_joint_limits.yaml` file in the `config` directory (to provide moveit support)

If you modified an already existing robot model:
- [ x ] you checked and optionally updated the table of verified data in `README.md` with the changes
- [ x ] you have run the `test_<robot_model>.launch.py` and the robot was visible in `rviz`

### Short description of the change
I have simulated the Kuka robot on an Isaac Sim environment. In order to do that I had to add a new TopicBased planning that is consumed by Isaac. I took inspiration from the Pandas robot where they have added this support.

https://github.com/ros-planning/moveit_resources/blob/humble/panda_moveit_config/config/panda.ros2_control.xacro#L7

I have added support only for the Agilus series for now. 
If a user sets `use_fake_hardware`, they can optionally set `enable_isaac_sim`, which will change the planner to deal with TopicBasedSystem controls.