### PR TITLE
kuka mock hw

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,16 @@
+---
+Language:        Cpp
+BasedOnStyle:  Google
+
+ColumnLimit: 100
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BreakBeforeBraces: Allman
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: true
+IncludeBlocks: Preserve
+InsertBraces: true
+...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install system hooks
-      run: sudo apt install -qq cppcheck libxml2-utils
+      run: sudo apt update && sudo apt install -y cppcheck libxml2-utils
     - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --all-files --hook-stage manual

--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ Github CI
 ## What is included?
 
 - `kuka_resources` contains general, common files. It is copied from [kuka_experimental](https://github.com/ros-industrial/kuka_experimental) and is ported from ROS to ROS2.
+- `kuka_agilus_support` contains urdf, config and mesh files for KUKA Agilus robots, it is copied from [kuka_experimental](https://github.com/ros-industrial/kuka_experimental) and ported to ROS2.
 - `kuka_cybertech_support` contains urdf, config and mesh files for KUKA cybertech robots.
+- `kuka_quantec_support` contains urdf, config and mesh files for KUKA quantec robots.
+- `kuka_fortec_support` contains urdf, config and mesh files for KUKA fortec robots.
 - `kuka_kr_moveit_config` contains configuration files for KUKA KR robots necessary for planning with MoveIt.
 - `kuka_lbr_iisy_support` contains urdf, config and mesh files for KUKA iisy robots.
 - `kuka_lbr_iisy_moveit_config` contains configuration files for KUKA LBR iisy robots necessary for planning with MoveIt.
-- `kuka_agilus_support` contains urdf, config and mesh files for KUKA Agilus robots, it is copied from [kuka_experimental](https://github.com/ros-industrial/kuka_experimental) and ported to ROS2.
 - `kuka_lbr_iiwa_support` contains urdf, config and mesh files for KUKA LBR iiwa robots
 - `kuka_lbr_iiwa_moveit_config` contains configuration files for KUKA LBR iiwa robots necessary for planning with MoveIt.
+- `kuka_mock_hardware_interface` contains a custom mock hardware interface for KUKA robots
 
 ## Structure of the support packages
 
@@ -93,7 +96,17 @@ Some of the data in the xacros might not be valid or missing, the following tabl
 |kr210_r3100_2| quantec | ✓ | ✓ | ✓ | ✓ | | |
 |kr560_r3100_2| fortec | ✓ | ✓ | ✓ | ✓ | | ✓|
 
-## Starting the move group server with fake hardware
+## Custom mock hardware 
+
+The repository also contains a mock hardware interface implementation, that extends the `mock_components::GenericSystem` defined in the `hardware_interface` package.
+This is necessary, as the driver workflow also activates controllers, which is possible only if all of the interfaces claimed by the controller is provided by the hardware interface. This would not be the case for the default `GenericSystem`, therefore all of the custom state and command interfaces used by the drivers are exported by the `KukaMockHardwareInterface`.
+Additionally two hardware parameters are added:
+- To support similiar timing behaviour as the actual robots, the mock hardware was extended with a blocking wait, so that the read function does not return immediately, but cyclically. The frequency of the loops is defined by the `cycle_time_ms` parameter. Default value is 4  [ms].
+- To be able to test whether a specific setup would fit into the roundtrip time enforced by a real robot, the `roundtrip_time_micro` parameter can be used. If the `write()` method is not called before the given timeout is exceeded (starting from the previous `read()` function), a warning message is logged (but the return value of the `write()` will be still SUCCESS). Default value is 0 [us], which means, that the roundrip time should not be monitored.
+
+The mock hardware was implemented in this repository to allow testing moveit without having to build the driver code.
+
+## Starting the move group server with mock hardware
 
 To start `rviz` with the motion planning plugin using fake hardware, the following launch files can be used:
 

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ Some of the data in the xacros might not be valid or missing, the following tabl
 |kr210_r3100_2| quantec | ✓ | ✓ | ✓ | ✓ | | |
 |kr560_r3100_2| fortec | ✓ | ✓ | ✓ | ✓ | | ✓|
 
-## Custom mock hardware 
+## Custom mock hardware
 
 The repository also contains a mock hardware interface implementation, that extends the `mock_components::GenericSystem` defined in the `hardware_interface` package.
 This is necessary, as the driver workflow also activates controllers, which is possible only if all of the interfaces claimed by the controller is provided by the hardware interface. This would not be the case for the default `GenericSystem`, therefore all of the custom state and command interfaces used by the drivers are exported by the `KukaMockHardwareInterface`.
 Additionally two hardware parameters are added:
-- To support similiar timing behaviour as the actual robots, the mock hardware was extended with a blocking wait, so that the read function does not return immediately, but cyclically. The frequency of the loops is defined by the `cycle_time_ms` parameter. Default value is 4  [ms].
+- To support similar timing behaviour as the actual robots, the mock hardware was extended with a blocking wait, so that the read function does not return immediately, but cyclically. The frequency of the loops is defined by the `cycle_time_ms` parameter. Default value is 4  [ms].
 - To be able to test whether a specific setup would fit into the roundtrip time enforced by a real robot, the `roundtrip_time_micro` parameter can be used. If the `write()` method is not called before the given timeout is exceeded (starting from the previous `read()` function), a warning message is logged (but the return value of the `write()` will be still SUCCESS). Default value is 0 [us], which means, that the roundrip time should not be monitored.
 
 The mock hardware was implemented in this repository to allow testing moveit without having to build the driver code.

--- a/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
+++ b/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
@@ -4,7 +4,7 @@
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>mock_components/GenericSystem</plugin>
+          <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
+++ b/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
@@ -5,6 +5,8 @@
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
+          <param name="cycle_time_ms">4</param>
+          <param name="roundtrip_time_micro">4000</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
+++ b/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
@@ -4,7 +4,7 @@
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>mock_components/GenericSystem</plugin>
+          <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
+++ b/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
@@ -5,6 +5,8 @@
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
+          <param name="cycle_time_ms">4</param>
+          <param name="roundtrip_time_micro">4000</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
+++ b/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
@@ -4,7 +4,7 @@
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>mock_components/GenericSystem</plugin>
+          <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
+++ b/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
@@ -5,6 +5,8 @@
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
+          <param name="cycle_time_ms">4</param>
+          <param name="roundtrip_time_micro">4000</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_kr_moveit_config/launch/moveit_planning_fake_hardware.launch.py
+++ b/kuka_kr_moveit_config/launch/moveit_planning_fake_hardware.launch.py
@@ -65,8 +65,6 @@ def launch_setup(context, *args, **kwargs):
             ]
         ),
         launch_arguments={
-            "robot_model": f"{robot_model.perform(context)}",
-            "robot_family": f"{robot_family.perform(context)}",
             "dof": f"{6}",
         }.items(),
     )

--- a/kuka_lbr_iisy_moveit_config/launch/moveit_planning_fake_hardware.launch.py
+++ b/kuka_lbr_iisy_moveit_config/launch/moveit_planning_fake_hardware.launch.py
@@ -64,7 +64,6 @@ def launch_setup(context, *args, **kwargs):
             ]
         ),
         launch_arguments={
-            "robot_model": f"{robot_model.perform(context)}",
             "robot_family": "{}".format("lbr_iisy"),
             "dof": f"{6}",
         }.items(),

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
@@ -5,6 +5,8 @@
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
+          <param name="cycle_time_ms">4</param>
+          <param name="roundtrip_time_micro">2500</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
@@ -4,7 +4,7 @@
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>mock_components/GenericSystem</plugin>
+          <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_lbr_iiwa_moveit_config/launch/moveit_planning_fake_hardware.launch.py
+++ b/kuka_lbr_iiwa_moveit_config/launch/moveit_planning_fake_hardware.launch.py
@@ -64,7 +64,6 @@ def launch_setup(context, *args, **kwargs):
             ]
         ),
         launch_arguments={
-            "robot_model": f"{robot_model.perform(context)}",
             "robot_family": "{}".format("lbr_iiwa"),
             "dof": f"{7}",
         }.items(),

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820.urdf.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820.urdf.xacro
@@ -3,9 +3,6 @@
   <!-- Import iiwa urdf file  -->
   <xacro:include filename="$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa14_r820_macro.xacro"/>
   <!-- Read additional arguments  -->
-  <xacro:arg name="controller_ip" default="0.0.0.0"/>
-  <xacro:arg name="client_ip" default="0.0.0.0"/>
-  <xacro:arg name="client_port" default="30200"/>
   <xacro:arg name="use_fake_hardware" default="false"/>
   <xacro:arg name="x" default="0"/>
   <xacro:arg name="y" default="0"/>
@@ -14,7 +11,7 @@
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
   <xacro:arg name="prefix" default=""/>
-  <xacro:kuka_lbr_iiwa14_r820_robot prefix="$(arg prefix)" io_access="false" use_fake_hardware="$(arg use_fake_hardware)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" client_port="$(arg client_port)">
+  <xacro:kuka_lbr_iiwa14_r820_robot prefix="$(arg prefix)" io_access="false" use_fake_hardware="$(arg use_fake_hardware)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_lbr_iiwa14_r820_robot>
 </robot>

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820.urdf.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820.urdf.xacro
@@ -3,6 +3,9 @@
   <!-- Import iiwa urdf file  -->
   <xacro:include filename="$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa14_r820_macro.xacro"/>
   <!-- Read additional arguments  -->
+  <xacro:arg name="controller_ip" default="0.0.0.0"/>
+  <xacro:arg name="client_ip" default="0.0.0.0"/>
+  <xacro:arg name="client_port" default="30200"/>
   <xacro:arg name="use_fake_hardware" default="false"/>
   <xacro:arg name="x" default="0"/>
   <xacro:arg name="y" default="0"/>
@@ -11,7 +14,7 @@
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
   <xacro:arg name="prefix" default=""/>
-  <xacro:kuka_lbr_iiwa14_r820_robot prefix="$(arg prefix)" io_access="false" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_lbr_iiwa14_r820_robot prefix="$(arg prefix)" io_access="false" use_fake_hardware="$(arg use_fake_hardware)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" client_port="$(arg client_port)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_lbr_iiwa14_r820_robot>
 </robot>

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820_macro.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820_macro.xacro
@@ -4,9 +4,9 @@
   <xacro:include filename="$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa_transmission.xacro"/>
-  <xacro:macro name="kuka_lbr_iiwa14_r820_robot" params="io_access prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_lbr_iiwa14_r820_robot" params="io_access prefix use_fake_hardware controller_ip client_ip client_port *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_lbr_iiwa_ros2_control name="${prefix}lbr_iiwa14_r820" prefix="${prefix}" io_access="${io_access}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_lbr_iiwa_ros2_control name="${prefix}lbr_iiwa14_r820" prefix="${prefix}" io_access="${io_access}" use_fake_hardware="${use_fake_hardware}" controller_ip="${controller_ip}" client_ip="${client_ip}" client_port="${client_port}"/>
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820_macro.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820_macro.xacro
@@ -4,9 +4,9 @@
   <xacro:include filename="$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa_transmission.xacro"/>
-  <xacro:macro name="kuka_lbr_iiwa14_r820_robot" params="io_access prefix use_fake_hardware controller_ip client_ip client_port *origin">
+  <xacro:macro name="kuka_lbr_iiwa14_r820_robot" params="io_access prefix use_fake_hardware *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_lbr_iiwa_ros2_control name="${prefix}lbr_iiwa14_r820" prefix="${prefix}" io_access="${io_access}" use_fake_hardware="${use_fake_hardware}" controller_ip="${controller_ip}" client_ip="${client_ip}" client_port="${client_port}"/>
+    <xacro:kuka_lbr_iiwa_ros2_control name="${prefix}lbr_iiwa14_r820" prefix="${prefix}" io_access="${io_access}" use_fake_hardware="${use_fake_hardware}"/>
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control.xacro
@@ -4,7 +4,7 @@
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>mock_components/GenericSystem</plugin>
+          <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_lbr_iiwa_ros2_control" params="name prefix io_access use_fake_hardware controller_ip client_ip client_port">
+  <xacro:macro name="kuka_lbr_iiwa_ros2_control" params="name prefix io_access use_fake_hardware">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
@@ -10,16 +10,11 @@
         </xacro:if>
         <xacro:unless value="${use_fake_hardware}">
           <plugin>kuka_sunrise_fri_driver::KukaFRIHardwareInterface</plugin>
-          <param name="controller_ip">${controller_ip}</param>
-          <param name="client_ip">${client_ip}</param>
-          <param name="client_port">${client_port}</param>
         </xacro:unless>
       </hardware>
       <!-- define joints and command/state interfaces for each joint -->
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -33,8 +28,6 @@
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -48,8 +41,6 @@
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -63,8 +54,6 @@
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -78,8 +67,6 @@
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -93,8 +80,6 @@
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -108,8 +93,6 @@
       </joint>
       <joint name="${prefix}joint_7">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -121,6 +104,7 @@
           <param name="initial_value">0.0</param>
         </state_interface>
       </joint>
+      <!-- TODO(Svastits): update GPIO list from config file-->
       <xacro:unless value="${use_fake_hardware}">
         <xacro:if value="${io_access}">
           <xacro:include filename="$(find kuka_sunrise_fri_driver)/config/gpio_config.xacro"/>

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control.xacro
@@ -5,6 +5,8 @@
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
+          <param name="cycle_time_ms">5</param>
+          <param name="roundtrip_time_micro">5000</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_lbr_iiwa_ros2_control" params="name prefix io_access use_fake_hardware">
+  <xacro:macro name="kuka_lbr_iiwa_ros2_control" params="name prefix io_access use_fake_hardware controller_ip client_ip client_port">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
@@ -10,11 +10,16 @@
         </xacro:if>
         <xacro:unless value="${use_fake_hardware}">
           <plugin>kuka_sunrise_fri_driver::KukaFRIHardwareInterface</plugin>
+          <param name="controller_ip">${controller_ip}</param>
+          <param name="client_ip">${client_ip}</param>
+          <param name="client_port">${client_port}</param>
         </xacro:unless>
       </hardware>
       <!-- define joints and command/state interfaces for each joint -->
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
+        <command_interface name="stiffness"/>
+        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -28,6 +33,8 @@
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
+        <command_interface name="stiffness"/>
+        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -41,6 +48,8 @@
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
+        <command_interface name="stiffness"/>
+        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -54,6 +63,8 @@
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
+        <command_interface name="stiffness"/>
+        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -67,6 +78,8 @@
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
+        <command_interface name="stiffness"/>
+        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -80,6 +93,8 @@
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
+        <command_interface name="stiffness"/>
+        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -93,6 +108,8 @@
       </joint>
       <joint name="${prefix}joint_7">
         <command_interface name="position"/>
+        <command_interface name="stiffness"/>
+        <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
@@ -104,7 +121,6 @@
           <param name="initial_value">0.0</param>
         </state_interface>
       </joint>
-      <!-- TODO(Svastits): update GPIO list from config file-->
       <xacro:unless value="${use_fake_hardware}">
         <xacro:if value="${io_access}">
           <xacro:include filename="$(find kuka_sunrise_fri_driver)/config/gpio_config.xacro"/>

--- a/kuka_mock_hardware_interface/CMakeLists.txt
+++ b/kuka_mock_hardware_interface/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.5)
+project(kuka_mock_hardware_interface)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+
+include_directories(include)
+
+add_library(${PROJECT_NAME} SHARED
+  src/hardware_interface.cpp
+)
+
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${PROJECT_NAME} PRIVATE "KUKA_MOCK_HARDWARE_INTERFACE_BUILDING_LIBRARY")
+
+ament_target_dependencies(${PROJECT_NAME} rclcpp hardware_interface)
+
+pluginlib_export_plugin_description_file(hardware_interface hardware_interface.xml)
+
+install(TARGETS ${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+endif()
+
+ament_package()

--- a/kuka_mock_hardware_interface/hardware_interface.xml
+++ b/kuka_mock_hardware_interface/hardware_interface.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<library path="kuka_mock_hardware_interface">
+  <class type="kuka_mock_hardware_interface::KukaMockHardwareInterface" base_class_type="hardware_interface::SystemInterface"/>
+  <description>
+        ROS2 control mock hardware interface for KUKA robots.
+    </description>
+</library>

--- a/kuka_mock_hardware_interface/include/kuka_mock_hardware_interface/hardware_interface.hpp
+++ b/kuka_mock_hardware_interface/include/kuka_mock_hardware_interface/hardware_interface.hpp
@@ -1,0 +1,165 @@
+// Copyright (c) 2021 PickNik, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Jafar Abdi, Denis Stogl
+// Maintainer: Aron Svastits
+
+#ifndef KUKA_MOCK_HARDWARE_INTERFACE__HARDWARE_INTERFACE_HPP_
+#define KUKA_MOCK_HARDWARE_INTERFACE__HARDWARE_INTERFACE_HPP_
+
+#include <string>
+#include <vector>
+
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+
+using hardware_interface::return_type;
+
+namespace kuka_mock_hardware_interface
+{
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+static constexpr size_t POSITION_INTERFACE_INDEX = 0;
+static constexpr size_t VELOCITY_INTERFACE_INDEX = 1;
+static constexpr size_t ACCELERATION_INTERFACE_INDEX = 2;
+
+class HARDWARE_INTERFACE_PUBLIC KukaMockHardwareInterface
+: public hardware_interface::SystemInterface
+{
+public:
+  CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
+  CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
+
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+  return_type prepare_command_mode_switch(
+    const std::vector<std::string> & start_interfaces,
+    const std::vector<std::string> & stop_interfaces) override;
+
+  return_type perform_command_mode_switch(
+    const std::vector<std::string> & start_interfaces,
+    const std::vector<std::string> & stop_interfaces) override;
+
+  return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+  return_type write(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+protected:
+  /// Use standard interfaces for joints because they are relevant for dynamic behavior
+  /**
+   * By splitting the standard interfaces from other type, the users are able to inherit this
+   * class and simply create small "simulation" with desired dynamic behavior.
+   * The advantage over using Gazebo is that enables "quick & dirty" tests of robot's URDF and
+   * controllers.
+   */
+  const std::vector<std::string> standard_interfaces_ = {
+    hardware_interface::HW_IF_POSITION, hardware_interface::HW_IF_VELOCITY,
+    hardware_interface::HW_IF_ACCELERATION, hardware_interface::HW_IF_EFFORT};
+
+  struct MimicJoint
+  {
+    std::size_t joint_index;
+    std::size_t mimicked_joint_index;
+    double multiplier = 1.0;
+  };
+  std::vector<MimicJoint> mimic_joints_;
+
+  /// The size of this vector is (standard_interfaces_.size() x nr_joints)
+  std::vector<std::vector<double>> joint_commands_;
+  std::vector<std::vector<double>> joint_states_;
+
+  std::vector<std::string> other_interfaces_;
+  /// The size of this vector is (other_interfaces_.size() x nr_joints)
+  std::vector<std::vector<double>> other_commands_;
+  std::vector<std::vector<double>> other_states_;
+
+  std::vector<std::string> sensor_interfaces_;
+  /// The size of this vector is (sensor_interfaces_.size() x nr_joints)
+  std::vector<std::vector<double>> sensor_mock_commands_;
+  std::vector<std::vector<double>> sensor_states_;
+
+  std::vector<std::string> gpio_interfaces_;
+  /// The size of this vector is (gpio_interfaces_.size() x nr_joints)
+  std::vector<std::vector<double>> gpio_mock_commands_;
+  std::vector<std::vector<double>> gpio_commands_;
+  std::vector<std::vector<double>> gpio_states_;
+
+  struct RobotState
+  {
+    double tracking_performance_ = 1;
+    // Enum values represented with doubles (as all interfaces must be pointers to doubles)
+    double session_state_ = 0;
+    double connection_quality_ = 0;
+    double command_mode_ = 0;
+    double safety_state_ = 0;
+    double control_mode_ = 0;
+    double operation_mode_ = 0;
+    double drive_state_ = 0;
+    double overlay_type_ = 0;
+  };
+
+  RobotState robot_state_;
+
+  double control_mode_ = 0;  // default to undefined
+  double receive_multiplier_ = 1;
+  double send_period_ms_ = 10;
+  double server_state_;
+
+  // KUKA-specific parameters
+  std::chrono::nanoseconds cycle_time_nano_;
+  int roundtrip_time_micro_;
+  bool init_clock_ = true;
+  std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> next_iteration_time_;
+
+private:
+  template <typename HandleType>
+  bool get_interface(
+    const std::string & name, const std::vector<std::string> & interface_list,
+    const std::string & interface_name, const size_t vector_index,
+    std::vector<std::vector<double>> & values, std::vector<HandleType> & interfaces);
+
+  void initialize_storage_vectors(
+    std::vector<std::vector<double>> & commands, std::vector<std::vector<double>> & states,
+    const std::vector<std::string> & interfaces,
+    const std::vector<hardware_interface::ComponentInfo> & component_infos);
+
+  template <typename InterfaceType>
+  bool populate_interfaces(
+    const std::vector<hardware_interface::ComponentInfo> & components,
+    std::vector<std::string> & interfaces, std::vector<std::vector<double>> & storage,
+    std::vector<InterfaceType> & target_interfaces, bool using_state_interfaces);
+
+  bool use_mock_gpio_command_interfaces_;
+  bool use_mock_sensor_command_interfaces_;
+
+  double position_state_following_offset_;
+  std::string custom_interface_with_following_offset_;
+  size_t index_custom_interface_with_following_offset_;
+
+  bool calculate_dynamics_;
+  std::vector<size_t> joint_control_mode_;
+
+  bool command_propagation_disabled_;
+};
+
+typedef KukaMockHardwareInterface GenericRobot;
+
+}  // namespace kuka_mock_hardware_interface
+
+#endif  // KUKA_MOCK_HARDWARE_INTERFACE__HARDWARE_INTERFACE_HPP_

--- a/kuka_mock_hardware_interface/include/kuka_mock_hardware_interface/hardware_interface_types.hpp
+++ b/kuka_mock_hardware_interface/include/kuka_mock_hardware_interface/hardware_interface_types.hpp
@@ -1,0 +1,63 @@
+// Copyright 2023 Áron Svastits
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a duplicate of the interface types in kuka_drivers_core to avoid depending on the drivers
+// repo
+
+#ifndef KUKA_MOCK_HARDWARE_INTERFACE__HARDWARE_INTERFACE_TYPES_HPP_
+#define KUKA_MOCK_HARDWARE_INTERFACE__HARDWARE_INTERFACE_TYPES_HPP_
+
+namespace hardware_interface
+{
+/* Custom interfaces */
+// Constant defining stiffness interface
+static constexpr char HW_IF_STIFFNESS[] = "stiffness";
+// Constant defining damping interface
+static constexpr char HW_IF_DAMPING[] = "damping";
+// Constant defining external torque interface
+static constexpr char HW_IF_EXTERNAL_TORQUE[] = "external_torque";
+
+/* Interface prefixes */
+// Constant defining prefix for I/O interfaces
+static constexpr char IO_PREFIX[] = "gpio";
+// Constant defining prefix for interfaces of "configuration controllers"
+static constexpr char CONFIG_PREFIX[] = "runtime_config";
+// Constant defining prefix for fri state
+static constexpr char FRI_STATE_PREFIX[] = "fri_state";
+// Constant defining prefix for states
+static constexpr char STATE_PREFIX[] = "state";
+
+/* Configuration interfaces */
+// Constant defining control_mode configuration interface
+static constexpr char CONTROL_MODE[] = "control_mode";
+// Constant defining the receive multiplier interface needed for FRI
+static constexpr char RECEIVE_MULTIPLIER[] = "receive_multiplier";
+static constexpr char SEND_PERIOD[] = "send_period_ms";
+
+/* FRI state interfaces */
+static constexpr char SESSION_STATE[] = "session_state";
+static constexpr char CONNECTION_QUALITY[] = "connection_quality";
+static constexpr char SAFETY_STATE[] = "safety_state";
+static constexpr char COMMAND_MODE[] = "command_mode";
+static constexpr char OPERATION_MODE[] = "operation_mode";
+static constexpr char DRIVE_STATE[] = "drive_state";
+static constexpr char OVERLAY_TYPE[] = "overlay_type";
+static constexpr char TRACKING_PERFORMANCE[] = "tracking_performance";
+
+// Constant defining server_state interface necessary for event broadcasting
+static constexpr char SERVER_STATE[] = "server_state";
+
+}  // namespace hardware_interface
+
+#endif  // KUKA_MOCK_HARDWARE_INTERFACE__HARDWARE_INTERFACE_TYPES_HPP_

--- a/kuka_mock_hardware_interface/include/kuka_mock_hardware_interface/visibility_control.h
+++ b/kuka_mock_hardware_interface/include/kuka_mock_hardware_interface/visibility_control.h
@@ -1,0 +1,49 @@
+//    Copyright 2024 Áron Svastits
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#ifndef KUKA_MOCK_HARDWARE_INTERFACE__VISIBILITY_CONTROL_H_
+#define KUKA_MOCK_HARDWARE_INTERFACE__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define KUKA_MOCK_HARDWARE_INTERFACE_EXPORT __attribute__((dllexport))
+#define KUKA_MOCK_HARDWARE_INTERFACE_IMPORT __attribute__((dllimport))
+#else
+#define KUKA_MOCK_HARDWARE_INTERFACE_EXPORT __declspec(dllexport)
+#define KUKA_MOCK_HARDWARE_INTERFACE_IMPORT __declspec(dllimport)
+#endif
+#ifdef KUKA_MOCK_HARDWARE_INTERFACE_BUILDING_LIBRARY
+#define KUKA_MOCK_HARDWARE_INTERFACE_PUBLIC KUKA_MOCK_HARDWARE_INTERFACE_EXPORT
+#else
+#define KUKA_MOCK_HARDWARE_INTERFACE_PUBLIC KUKA_MOCK_HARDWARE_INTERFACE_IMPORT
+#endif
+#define KUKA_MOCK_HARDWARE_INTERFACE_PUBLIC_TYPE KUKA_MOCK_HARDWARE_INTERFACE_PUBLIC
+#define KUKA_MOCK_HARDWARE_INTERFACE_LOCAL
+#else
+#define KUKA_MOCK_HARDWARE_INTERFACE_EXPORT __attribute__((visibility("default")))
+#define KUKA_MOCK_HARDWARE_INTERFACE_IMPORT
+#if __GNUC__ >= 4
+#define KUKA_MOCK_HARDWARE_INTERFACE_PUBLIC __attribute__((visibility("default")))
+#define KUKA_MOCK_HARDWARE_INTERFACE_LOCAL __attribute__((visibility("hidden")))
+#else
+#define KUKA_MOCK_HARDWARE_INTERFACE_PUBLIC
+#define KUKA_MOCK_HARDWARE_INTERFACE_LOCAL
+#endif
+#define KUKA_MOCK_HARDWARE_INTERFACE_PUBLIC_TYPE
+#endif
+
+#endif  // KUKA_MOCK_HARDWARE_INTERFACE__VISIBILITY_CONTROL_H_

--- a/kuka_mock_hardware_interface/package.xml
+++ b/kuka_mock_hardware_interface/package.xml
@@ -7,21 +7,7 @@
   <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
   <license>Apache 2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_cmake_python</buildtool_depend>
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
-  <depend>rclcpp</depend>
-  <depend>rclcpp_lifecycle</depend>
-  <depend>std_msgs</depend>
-  <depend>std_srvs</depend>
-  <depend>sensor_msgs</depend>
-  <depend>kuka_driver_interfaces</depend>
-  <depend>kuka_drivers_core</depend>
   <depend>hardware_interface</depend>
-  <depend>controller_manager_msgs</depend>
-  <exec_depend>ros2_control</exec_depend>
-  <exec_depend>ros2_controllers</exec_depend>
-  <exec_depend>fri_state_broadcaster</exec_depend>
-  <exec_depend>fri_configuration_controller</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/kuka_mock_hardware_interface/package.xml
+++ b/kuka_mock_hardware_interface/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>kuka_mock_hardware_interface</name>
+  <version>0.0.0</version>
+  <description>ROS2 control mock hardware for KUKA robots</description>
+  <maintainer email="svastits1@gmail.com">Aron Svastits</maintainer>
+  <license>Apache 2.0</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>kuka_driver_interfaces</depend>
+  <depend>kuka_drivers_core</depend>
+  <depend>hardware_interface</depend>
+  <depend>controller_manager_msgs</depend>
+  <exec_depend>ros2_control</exec_depend>
+  <exec_depend>ros2_controllers</exec_depend>
+  <exec_depend>fri_state_broadcaster</exec_depend>
+  <exec_depend>fri_configuration_controller</exec_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/kuka_mock_hardware_interface/src/hardware_interface.cpp
+++ b/kuka_mock_hardware_interface/src/hardware_interface.cpp
@@ -745,8 +745,7 @@ return_type KukaMockHardwareInterface::read(
   return return_type::OK;
 }
 
-return_type KukaMockHardwareInterface::write(
-  const rclcpp::Time & time, const rclcpp::Duration &)
+return_type KukaMockHardwareInterface::write(const rclcpp::Time & time, const rclcpp::Duration &)
 {
   if (roundtrip_time_micro_ != 0)
   {

--- a/kuka_mock_hardware_interface/src/hardware_interface.cpp
+++ b/kuka_mock_hardware_interface/src/hardware_interface.cpp
@@ -1,0 +1,869 @@
+// Copyright (c) 2021 PickNik, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Jafar Abdi, Denis Stogl
+// Maintainer: Aron Svastits
+
+#include "kuka_mock_hardware_interface/hardware_interface.hpp"
+#include "kuka_mock_hardware_interface/hardware_interface_types.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+#include <limits>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "hardware_interface/component_parser.hpp"
+#include "hardware_interface/lexical_casts.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "rcutils/logging_macros.h"
+
+namespace kuka_mock_hardware_interface
+{
+CallbackReturn KukaMockHardwareInterface::on_init(const hardware_interface::HardwareInfo & info)
+{
+  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
+  {
+    return CallbackReturn::ERROR;
+  }
+
+  auto populate_non_standard_interfaces =
+    [this](auto interface_list, auto & non_standard_interfaces)
+  {
+    for (const auto & interface : interface_list)
+    {
+      // add to list if non-standard interface
+      if (
+        std::find(standard_interfaces_.begin(), standard_interfaces_.end(), interface.name) ==
+        standard_interfaces_.end())
+      {
+        if (
+          std::find(
+            non_standard_interfaces.begin(), non_standard_interfaces.end(), interface.name) ==
+          non_standard_interfaces.end())
+        {
+          non_standard_interfaces.emplace_back(interface.name);
+        }
+      }
+    }
+  };
+
+  // check if to create mock command interface for sensor
+  auto it = info_.hardware_parameters.find("mock_sensor_commands");
+  if (it != info_.hardware_parameters.end())
+  {
+    use_mock_sensor_command_interfaces_ = hardware_interface::parse_bool(it->second);
+  }
+  else
+  {
+    // check if fake_sensor_commands was set instead and issue warning.
+    it = info_.hardware_parameters.find("fake_sensor_commands");
+    if (it != info_.hardware_parameters.end())
+    {
+      use_mock_sensor_command_interfaces_ = hardware_interface::parse_bool(it->second);
+      RCUTILS_LOG_WARN_NAMED(
+        "mock_generic_system",
+        "Parameter 'fake_sensor_commands' has been deprecated from usage. Use"
+        "'mock_sensor_commands' instead.");
+    }
+    else
+    {
+      use_mock_sensor_command_interfaces_ = false;
+    }
+  }
+
+  // check if to create mock command interface for gpio
+  it = info_.hardware_parameters.find("mock_gpio_commands");
+  if (it != info_.hardware_parameters.end())
+  {
+    use_mock_gpio_command_interfaces_ = hardware_interface::parse_bool(it->second);
+  }
+  else
+  {
+    // check if fake_gpio_commands was set instead and issue warning
+    it = info_.hardware_parameters.find("fake_gpio_commands");
+    if (it != info_.hardware_parameters.end())
+    {
+      use_mock_gpio_command_interfaces_ = hardware_interface::parse_bool(it->second);
+      RCUTILS_LOG_WARN_NAMED(
+        "mock_generic_system",
+        "Parameter 'fake_gpio_commands' has been deprecated from usage. Use"
+        "'mock_gpio_commands' instead.");
+    }
+    else
+    {
+      use_mock_gpio_command_interfaces_ = false;
+    }
+  }
+
+  // check if there is parameter that disables commands
+  // this way we simulate disconnected driver
+  it = info_.hardware_parameters.find("disable_commands");
+  if (it != info.hardware_parameters.end())
+  {
+    command_propagation_disabled_ = hardware_interface::parse_bool(it->second);
+  }
+  else
+  {
+    command_propagation_disabled_ = false;
+  }
+
+  // check if there is parameter that enables dynamic calculation
+  it = info_.hardware_parameters.find("calculate_dynamics");
+  if (it != info.hardware_parameters.end())
+  {
+    calculate_dynamics_ = hardware_interface::parse_bool(it->second);
+  }
+  else
+  {
+    calculate_dynamics_ = false;
+  }
+
+  // process parameters about state following
+  position_state_following_offset_ = 0.0;
+  custom_interface_with_following_offset_ = "";
+
+  it = info_.hardware_parameters.find("position_state_following_offset");
+  if (it != info_.hardware_parameters.end())
+  {
+    position_state_following_offset_ = std::stod(it->second);
+    it = info_.hardware_parameters.find("custom_interface_with_following_offset");
+    if (it != info_.hardware_parameters.end())
+    {
+      custom_interface_with_following_offset_ = it->second;
+    }
+  }
+
+  // Parse KUKA-specific parameters
+  it = info_.hardware_parameters.find("cycle_time_ms");
+  if (it != info.hardware_parameters.end())
+  {
+    cycle_time_nano_ = std::chrono::nanoseconds(std::stoi(it->second) * 1'000'000);
+  }
+  else
+  {
+    cycle_time_nano_ = std::chrono::nanoseconds(4'000'000);  // Default to 4 ms
+  }
+
+  it = info_.hardware_parameters.find("roundtrip_time_micro");
+  if (it != info.hardware_parameters.end())
+  {
+    roundtrip_time_micro_ = std::stod(it->second);
+  }
+  else
+  {
+    roundtrip_time_micro_ = 0;  // Default to no timeout checking
+  }
+
+  // its extremlly improbably that std::distance results int this value - therefore default
+  index_custom_interface_with_following_offset_ = std::numeric_limits<size_t>::max();
+
+  // Initialize storage for standard interfaces
+  initialize_storage_vectors(joint_commands_, joint_states_, standard_interfaces_, info_.joints);
+  // set all values without initial values to 0
+  for (auto i = 0u; i < info_.joints.size(); i++)
+  {
+    for (auto j = 0u; j < standard_interfaces_.size(); j++)
+    {
+      if (std::isnan(joint_states_[j][i]))
+      {
+        joint_states_[j][i] = 0.0;
+      }
+    }
+  }
+
+  // Search for mimic joints
+  for (auto i = 0u; i < info_.joints.size(); ++i)
+  {
+    const auto & joint = info_.joints.at(i);
+    if (joint.parameters.find("mimic") != joint.parameters.cend())
+    {
+      const auto mimicked_joint_it = std::find_if(
+        info_.joints.begin(), info_.joints.end(),
+        [&mimicked_joint =
+           joint.parameters.at("mimic")](const hardware_interface::ComponentInfo & joint_info)
+        { return joint_info.name == mimicked_joint; });
+      if (mimicked_joint_it == info_.joints.cend())
+      {
+        throw std::runtime_error(
+          std::string("Mimicked joint '") + joint.parameters.at("mimic") + "' not found");
+      }
+      MimicJoint mimic_joint;
+      mimic_joint.joint_index = i;
+      mimic_joint.mimicked_joint_index = std::distance(info_.joints.begin(), mimicked_joint_it);
+      auto param_it = joint.parameters.find("multiplier");
+      if (param_it != joint.parameters.end())
+      {
+        mimic_joint.multiplier = std::stod(joint.parameters.at("multiplier"));
+      }
+      mimic_joints_.push_back(mimic_joint);
+    }
+  }
+
+  // search for non-standard joint interfaces
+  for (const auto & joint : info_.joints)
+  {
+    // populate non-standard command interfaces to other_interfaces_
+    populate_non_standard_interfaces(joint.command_interfaces, other_interfaces_);
+
+    // populate non-standard state interfaces to other_interfaces_
+    populate_non_standard_interfaces(joint.state_interfaces, other_interfaces_);
+  }
+
+  // Initialize storage for non-standard interfaces
+  initialize_storage_vectors(other_commands_, other_states_, other_interfaces_, info_.joints);
+
+  // when following offset is used on custom interface then find its index
+  if (!custom_interface_with_following_offset_.empty())
+  {
+    auto if_it = std::find(
+      other_interfaces_.begin(), other_interfaces_.end(), custom_interface_with_following_offset_);
+    if (if_it != other_interfaces_.end())
+    {
+      index_custom_interface_with_following_offset_ =
+        std::distance(other_interfaces_.begin(), if_it);
+      RCUTILS_LOG_INFO_NAMED(
+        "mock_generic_system", "Custom interface with following offset '%s' found at index: %zu.",
+        custom_interface_with_following_offset_.c_str(),
+        index_custom_interface_with_following_offset_);
+    }
+    else
+    {
+      RCUTILS_LOG_WARN_NAMED(
+        "mock_generic_system",
+        "Custom interface with following offset '%s' does not exist. Offset will not be applied",
+        custom_interface_with_following_offset_.c_str());
+    }
+  }
+
+  for (const auto & sensor : info_.sensors)
+  {
+    for (const auto & interface : sensor.state_interfaces)
+    {
+      if (
+        std::find(sensor_interfaces_.begin(), sensor_interfaces_.end(), interface.name) ==
+        sensor_interfaces_.end())
+      {
+        sensor_interfaces_.emplace_back(interface.name);
+      }
+    }
+  }
+  initialize_storage_vectors(
+    sensor_mock_commands_, sensor_states_, sensor_interfaces_, info_.sensors);
+
+  // search for gpio interfaces
+  for (const auto & gpio : info_.gpios)
+  {
+    // populate non-standard command interfaces to gpio_interfaces_
+    populate_non_standard_interfaces(gpio.command_interfaces, gpio_interfaces_);
+
+    // populate non-standard state interfaces to gpio_interfaces_
+    populate_non_standard_interfaces(gpio.state_interfaces, gpio_interfaces_);
+  }
+
+  // Mock gpio command interfaces
+  if (use_mock_gpio_command_interfaces_)
+  {
+    initialize_storage_vectors(gpio_mock_commands_, gpio_states_, gpio_interfaces_, info_.gpios);
+  }
+  // Real gpio command interfaces
+  else
+  {
+    initialize_storage_vectors(gpio_commands_, gpio_states_, gpio_interfaces_, info_.gpios);
+  }
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn KukaMockHardwareInterface::on_configure(const rclcpp_lifecycle::State &)
+{
+  init_clock_ = true;
+  return CallbackReturn::SUCCESS;
+}
+
+std::vector<hardware_interface::StateInterface> KukaMockHardwareInterface::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> state_interfaces;
+
+  // Joints' state interfaces
+  for (auto i = 0u; i < info_.joints.size(); i++)
+  {
+    const auto & joint = info_.joints[i];
+    for (const auto & interface : joint.state_interfaces)
+    {
+      // Add interface: if not in the standard list then use "other" interface list
+      if (!get_interface(
+            joint.name, standard_interfaces_, interface.name, i, joint_states_, state_interfaces))
+      {
+        if (!get_interface(
+              joint.name, other_interfaces_, interface.name, i, other_states_, state_interfaces))
+        {
+          throw std::runtime_error(
+            "Interface is not found in the standard nor other list. "
+            "This should never happen!");
+        }
+      }
+    }
+  }
+
+  // Sensor state interfaces
+  if (!populate_interfaces(
+        info_.sensors, sensor_interfaces_, sensor_states_, state_interfaces, true))
+  {
+    throw std::runtime_error(
+      "Interface is not found in the standard nor other list. This should never happen!");
+  };
+
+  // GPIO state interfaces
+  if (!populate_interfaces(info_.gpios, gpio_interfaces_, gpio_states_, state_interfaces, true))
+  {
+    throw std::runtime_error("Interface is not found in the gpio list. This should never happen!");
+  }
+
+  state_interfaces.emplace_back(
+    hardware_interface::FRI_STATE_PREFIX, hardware_interface::SESSION_STATE,
+    &robot_state_.session_state_);
+  state_interfaces.emplace_back(
+    hardware_interface::FRI_STATE_PREFIX, hardware_interface::CONNECTION_QUALITY,
+    &robot_state_.connection_quality_);
+  state_interfaces.emplace_back(
+    hardware_interface::FRI_STATE_PREFIX, hardware_interface::SAFETY_STATE,
+    &robot_state_.safety_state_);
+  state_interfaces.emplace_back(
+    hardware_interface::FRI_STATE_PREFIX, hardware_interface::COMMAND_MODE,
+    &robot_state_.command_mode_);
+  state_interfaces.emplace_back(
+    hardware_interface::FRI_STATE_PREFIX, hardware_interface::CONTROL_MODE,
+    &robot_state_.control_mode_);
+  state_interfaces.emplace_back(
+    hardware_interface::FRI_STATE_PREFIX, hardware_interface::OPERATION_MODE,
+    &robot_state_.operation_mode_);
+  state_interfaces.emplace_back(
+    hardware_interface::FRI_STATE_PREFIX, hardware_interface::DRIVE_STATE,
+    &robot_state_.drive_state_);
+  state_interfaces.emplace_back(
+    hardware_interface::FRI_STATE_PREFIX, hardware_interface::OVERLAY_TYPE,
+    &robot_state_.overlay_type_);
+  state_interfaces.emplace_back(
+    hardware_interface::FRI_STATE_PREFIX, hardware_interface::TRACKING_PERFORMANCE,
+    &robot_state_.tracking_performance_);
+  state_interfaces.emplace_back(
+    hardware_interface::STATE_PREFIX, hardware_interface::SERVER_STATE, &server_state_);
+
+  return state_interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface>
+KukaMockHardwareInterface::export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> command_interfaces;
+
+  // Joints' state interfaces
+  for (size_t i = 0; i < info_.joints.size(); ++i)
+  {
+    const auto & joint = info_.joints[i];
+    for (const auto & interface : joint.command_interfaces)
+    {
+      // Add interface: if not in the standard list than use "other" interface list
+      if (!get_interface(
+            joint.name, standard_interfaces_, interface.name, i, joint_commands_,
+            command_interfaces))
+      {
+        if (!get_interface(
+              joint.name, other_interfaces_, interface.name, i, other_commands_,
+              command_interfaces))
+        {
+          throw std::runtime_error(
+            "Interface is not found in the standard nor other list. "
+            "This should never happen!");
+        }
+      }
+    }
+  }
+  // Set position control mode per default
+  joint_control_mode_.resize(info_.joints.size(), POSITION_INTERFACE_INDEX);
+
+  // Mock sensor command interfaces
+  if (use_mock_sensor_command_interfaces_)
+  {
+    if (!populate_interfaces(
+          info_.sensors, sensor_interfaces_, sensor_mock_commands_, command_interfaces, true))
+    {
+      throw std::runtime_error(
+        "Interface is not found in the standard nor other list. This should never happen!");
+    }
+  }
+
+  // Mock gpio command interfaces (consider all state interfaces for command interfaces)
+  if (use_mock_gpio_command_interfaces_)
+  {
+    if (!populate_interfaces(
+          info_.gpios, gpio_interfaces_, gpio_mock_commands_, command_interfaces, true))
+    {
+      throw std::runtime_error(
+        "Interface is not found in the gpio list. This should never happen!");
+    }
+  }
+  // GPIO command interfaces (real command interfaces)
+  else
+  {
+    if (!populate_interfaces(
+          info_.gpios, gpio_interfaces_, gpio_commands_, command_interfaces, false))
+    {
+      throw std::runtime_error(
+        "Interface is not found in the gpio list. This should never happen!");
+    }
+  }
+
+  command_interfaces.emplace_back(
+    hardware_interface::CONFIG_PREFIX, hardware_interface::CONTROL_MODE, &control_mode_);
+  command_interfaces.emplace_back(
+    hardware_interface::CONFIG_PREFIX, hardware_interface::RECEIVE_MULTIPLIER,
+    &receive_multiplier_);
+  command_interfaces.emplace_back(
+    hardware_interface::CONFIG_PREFIX, hardware_interface::SEND_PERIOD, &send_period_ms_);
+
+  return command_interfaces;
+}
+
+return_type KukaMockHardwareInterface::prepare_command_mode_switch(
+  const std::vector<std::string> & start_interfaces,
+  const std::vector<std::string> & /*stop_interfaces*/)
+{
+  hardware_interface::return_type ret_val = hardware_interface::return_type::OK;
+
+  if (!calculate_dynamics_)
+  {
+    return ret_val;
+  }
+
+  const size_t FOUND_ONCE_FLAG = 1000000;
+
+  std::vector<size_t> joint_found_in_x_requests_;
+  joint_found_in_x_requests_.resize(info_.joints.size(), 0);
+
+  for (const auto & key : start_interfaces)
+  {
+    // check if interface is joint
+    auto joint_it_found = std::find_if(
+      info_.joints.begin(), info_.joints.end(),
+      [key](const auto & joint) { return (key.find(joint.name) != std::string::npos); });
+
+    if (joint_it_found != info_.joints.end())
+    {
+      const size_t joint_index = std::distance(info_.joints.begin(), joint_it_found);
+      if (joint_found_in_x_requests_[joint_index] == 0)
+      {
+        joint_found_in_x_requests_[joint_index] = FOUND_ONCE_FLAG;
+      }
+
+      if (key == info_.joints[joint_index].name + "/" + hardware_interface::HW_IF_POSITION)
+      {
+        joint_found_in_x_requests_[joint_index] += 1;
+      }
+      if (key == info_.joints[joint_index].name + "/" + hardware_interface::HW_IF_VELOCITY)
+      {
+        if (!calculate_dynamics_)
+        {
+          RCUTILS_LOG_WARN_NAMED(
+            "mock_generic_system",
+            "Requested velocity mode for joint '%s' without dynamics calculation enabled - this "
+            "might lead to wrong feedback and unexpected behavior.",
+            info_.joints[joint_index].name.c_str());
+        }
+        joint_found_in_x_requests_[joint_index] += 1;
+      }
+      if (key == info_.joints[joint_index].name + "/" + hardware_interface::HW_IF_ACCELERATION)
+      {
+        if (!calculate_dynamics_)
+        {
+          RCUTILS_LOG_WARN_NAMED(
+            "mock_generic_system",
+            "Requested acceleration mode for joint '%s' without dynamics calculation enabled - "
+            "this might lead to wrong feedback and unexpected behavior.",
+            info_.joints[joint_index].name.c_str());
+        }
+        joint_found_in_x_requests_[joint_index] += 1;
+      }
+    }
+    else
+    {
+      RCUTILS_LOG_DEBUG_NAMED(
+        "mock_generic_system", "Got interface '%s' that is not joint - nothing to do!",
+        key.c_str());
+    }
+  }
+
+  for (size_t i = 0; i < info_.joints.size(); ++i)
+  {
+    // There has to always be at least one control mode from the above three set
+    if (joint_found_in_x_requests_[i] == FOUND_ONCE_FLAG)
+    {
+      RCUTILS_LOG_ERROR_NAMED(
+        "mock_generic_system", "Joint '%s' has to have '%s', '%s', or '%s' interface!",
+        info_.joints[i].name.c_str(), hardware_interface::HW_IF_POSITION,
+        hardware_interface::HW_IF_VELOCITY, hardware_interface::HW_IF_ACCELERATION);
+      ret_val = hardware_interface::return_type::ERROR;
+    }
+
+    // Currently we don't support multiple interface request
+    if (joint_found_in_x_requests_[i] > (FOUND_ONCE_FLAG + 1))
+    {
+      RCUTILS_LOG_ERROR_NAMED(
+        "mock_generic_system",
+        "Got multiple (%zu) starting interfaces for joint '%s' - this is not "
+        "supported!",
+        joint_found_in_x_requests_[i] - FOUND_ONCE_FLAG, info_.joints[i].name.c_str());
+      ret_val = hardware_interface::return_type::ERROR;
+    }
+  }
+
+  return ret_val;
+}
+
+return_type KukaMockHardwareInterface::perform_command_mode_switch(
+  const std::vector<std::string> & start_interfaces,
+  const std::vector<std::string> & /*stop_interfaces*/)
+{
+  if (!calculate_dynamics_)
+  {
+    return hardware_interface::return_type::OK;
+  }
+
+  for (const auto & key : start_interfaces)
+  {
+    // check if interface is joint
+    auto joint_it_found = std::find_if(
+      info_.joints.begin(), info_.joints.end(),
+      [key](const auto & joint) { return (key.find(joint.name) != std::string::npos); });
+
+    if (joint_it_found != info_.joints.end())
+    {
+      const size_t joint_index = std::distance(info_.joints.begin(), joint_it_found);
+
+      if (key == info_.joints[joint_index].name + "/" + hardware_interface::HW_IF_POSITION)
+      {
+        joint_control_mode_[joint_index] = POSITION_INTERFACE_INDEX;
+      }
+      if (key == info_.joints[joint_index].name + "/" + hardware_interface::HW_IF_VELOCITY)
+      {
+        joint_control_mode_[joint_index] = VELOCITY_INTERFACE_INDEX;
+      }
+      if (key == info_.joints[joint_index].name + "/" + hardware_interface::HW_IF_ACCELERATION)
+      {
+        joint_control_mode_[joint_index] = ACCELERATION_INTERFACE_INDEX;
+      }
+    }
+  }
+
+  return hardware_interface::return_type::OK;
+}
+
+return_type KukaMockHardwareInterface::read(
+  const rclcpp::Time & time, const rclcpp::Duration & period)
+{
+  if (command_propagation_disabled_)
+  {
+    RCUTILS_LOG_WARN_NAMED(
+      "mock_generic_system", "Command propagation is disabled - no values will be returned!");
+    return return_type::OK;
+  }
+
+  auto mirror_command_to_state = [](auto & states_, auto commands_, size_t start_index = 0)
+  {
+    for (size_t i = start_index; i < states_.size(); ++i)
+    {
+      for (size_t j = 0; j < states_[i].size(); ++j)
+      {
+        if (!std::isnan(commands_[i][j]))
+        {
+          states_[i][j] = commands_[i][j];
+        }
+      }
+    }
+  };
+
+  for (size_t j = 0; j < joint_states_[POSITION_INTERFACE_INDEX].size(); ++j)
+  {
+    if (calculate_dynamics_)
+    {
+      switch (joint_control_mode_[j])
+      {
+        case ACCELERATION_INTERFACE_INDEX:
+        {
+          // currently we do backward integration
+          joint_states_[POSITION_INTERFACE_INDEX][j] +=  // apply offset to positions only
+            joint_states_[VELOCITY_INTERFACE_INDEX][j] * period.seconds() +
+            (custom_interface_with_following_offset_.empty() ? position_state_following_offset_
+                                                             : 0.0);
+
+          joint_states_[VELOCITY_INTERFACE_INDEX][j] +=
+            joint_states_[ACCELERATION_INTERFACE_INDEX][j] * period.seconds();
+
+          if (!std::isnan(joint_commands_[ACCELERATION_INTERFACE_INDEX][j]))
+          {
+            joint_states_[ACCELERATION_INTERFACE_INDEX][j] =
+              joint_commands_[ACCELERATION_INTERFACE_INDEX][j];
+          }
+          break;
+        }
+        case VELOCITY_INTERFACE_INDEX:
+        {
+          // currently we do backward integration
+          joint_states_[POSITION_INTERFACE_INDEX][j] +=  // apply offset to positions only
+            joint_states_[VELOCITY_INTERFACE_INDEX][j] * period.seconds() +
+            (custom_interface_with_following_offset_.empty() ? position_state_following_offset_
+                                                             : 0.0);
+
+          if (!std::isnan(joint_commands_[VELOCITY_INTERFACE_INDEX][j]))
+          {
+            const double old_velocity = joint_states_[VELOCITY_INTERFACE_INDEX][j];
+
+            joint_states_[VELOCITY_INTERFACE_INDEX][j] =
+              joint_commands_[VELOCITY_INTERFACE_INDEX][j];
+
+            joint_states_[ACCELERATION_INTERFACE_INDEX][j] =
+              (joint_states_[VELOCITY_INTERFACE_INDEX][j] - old_velocity) / period.seconds();
+          }
+          break;
+        }
+        case POSITION_INTERFACE_INDEX:
+        {
+          if (!std::isnan(joint_commands_[POSITION_INTERFACE_INDEX][j]))
+          {
+            const double old_position = joint_states_[POSITION_INTERFACE_INDEX][j];
+            const double old_velocity = joint_states_[VELOCITY_INTERFACE_INDEX][j];
+
+            joint_states_[POSITION_INTERFACE_INDEX][j] =  // apply offset to positions only
+              joint_commands_[POSITION_INTERFACE_INDEX][j] +
+              (custom_interface_with_following_offset_.empty() ? position_state_following_offset_
+                                                               : 0.0);
+
+            joint_states_[VELOCITY_INTERFACE_INDEX][j] =
+              (joint_states_[POSITION_INTERFACE_INDEX][j] - old_position) / period.seconds();
+
+            joint_states_[ACCELERATION_INTERFACE_INDEX][j] =
+              (joint_states_[VELOCITY_INTERFACE_INDEX][j] - old_velocity) / period.seconds();
+          }
+          break;
+        }
+      }
+    }
+    else
+    {
+      for (size_t j = 0; j < joint_states_[POSITION_INTERFACE_INDEX].size(); ++j)
+      {
+        if (!std::isnan(joint_commands_[POSITION_INTERFACE_INDEX][j]))
+        {
+          joint_states_[POSITION_INTERFACE_INDEX][j] =  // apply offset to positions only
+            joint_commands_[POSITION_INTERFACE_INDEX][j] +
+            (custom_interface_with_following_offset_.empty() ? position_state_following_offset_
+                                                             : 0.0);
+        }
+      }
+    }
+  }
+
+  // do loopback on all other interfaces - starts from 1 or 3 because 0, 1, 3 are position,
+  // velocity, and acceleration interface
+  if (calculate_dynamics_)
+  {
+    mirror_command_to_state(joint_states_, joint_commands_, 3);
+  }
+  else
+  {
+    mirror_command_to_state(joint_states_, joint_commands_, 1);
+  }
+
+  for (const auto & mimic_joint : mimic_joints_)
+  {
+    for (auto i = 0u; i < joint_states_.size(); ++i)
+    {
+      joint_states_[i][mimic_joint.joint_index] =
+        mimic_joint.multiplier * joint_states_[i][mimic_joint.mimicked_joint_index];
+    }
+  }
+
+  for (size_t i = 0; i < other_states_.size(); ++i)
+  {
+    for (size_t j = 0; j < other_states_[i].size(); ++j)
+    {
+      if (
+        i == index_custom_interface_with_following_offset_ &&
+        !std::isnan(joint_commands_[POSITION_INTERFACE_INDEX][j]))
+      {
+        other_states_[i][j] =
+          joint_commands_[POSITION_INTERFACE_INDEX][j] + position_state_following_offset_;
+      }
+      else if (!std::isnan(other_commands_[i][j]))
+      {
+        other_states_[i][j] = other_commands_[i][j];
+      }
+    }
+  }
+
+  if (use_mock_sensor_command_interfaces_)
+  {
+    mirror_command_to_state(sensor_states_, sensor_mock_commands_);
+  }
+
+  // do loopback on all gpio interfaces
+  if (use_mock_gpio_command_interfaces_)
+  {
+    mirror_command_to_state(gpio_states_, gpio_mock_commands_);
+  }
+  else
+  {
+    mirror_command_to_state(gpio_states_, gpio_commands_);
+  }
+
+  if (init_clock_)
+  {
+    next_iteration_time_ =
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>(
+        std::chrono::nanoseconds(time.nanoseconds()));
+    init_clock_ = false;
+  }
+
+  next_iteration_time_ += std::chrono::nanoseconds(cycle_time_nano_);
+  std::this_thread::sleep_until(next_iteration_time_);
+
+  return return_type::OK;
+}
+
+return_type KukaMockHardwareInterface::write(
+  const rclcpp::Time & time, const rclcpp::Duration &)
+{
+  if (roundtrip_time_micro_ != 0)
+  {
+    if (
+      time.nanoseconds() >
+      next_iteration_time_.time_since_epoch().count() + roundtrip_time_micro_ * 1000)
+    {
+      RCUTILS_LOG_WARN_NAMED("mock_generic_system", "Cycle exceeded allowed round-trip time");
+    }
+  }
+  return return_type::OK;
+}
+
+// Private methods
+template <typename HandleType>
+bool KukaMockHardwareInterface::get_interface(
+  const std::string & name, const std::vector<std::string> & interface_list,
+  const std::string & interface_name, const size_t vector_index,
+  std::vector<std::vector<double>> & values, std::vector<HandleType> & interfaces)
+{
+  auto it = std::find(interface_list.begin(), interface_list.end(), interface_name);
+  if (it != interface_list.end())
+  {
+    auto j = std::distance(interface_list.begin(), it);
+    interfaces.emplace_back(name, *it, &values[j][vector_index]);
+    return true;
+  }
+  return false;
+}
+
+void KukaMockHardwareInterface::initialize_storage_vectors(
+  std::vector<std::vector<double>> & commands, std::vector<std::vector<double>> & states,
+  const std::vector<std::string> & interfaces,
+  const std::vector<hardware_interface::ComponentInfo> & component_infos)
+{
+  // Initialize storage for all joints, regardless of their existence
+  commands.resize(interfaces.size());
+  states.resize(interfaces.size());
+  for (auto i = 0u; i < interfaces.size(); i++)
+  {
+    commands[i].resize(component_infos.size(), std::numeric_limits<double>::quiet_NaN());
+    states[i].resize(component_infos.size(), std::numeric_limits<double>::quiet_NaN());
+  }
+
+  // Initialize with values from URDF
+  bool print_hint = false;
+  for (auto i = 0u; i < component_infos.size(); i++)
+  {
+    const auto & component = component_infos[i];
+    for (const auto & interface : component.state_interfaces)
+    {
+      auto it = std::find(interfaces.begin(), interfaces.end(), interface.name);
+
+      // If interface name is found in the interfaces list
+      if (it != interfaces.end())
+      {
+        auto index = std::distance(interfaces.begin(), it);
+
+        // Check the initial_value param is used
+        if (!interface.initial_value.empty())
+        {
+          states[index][i] = std::stod(interface.initial_value);
+        }
+        else
+        {
+          // Initialize the value in old way with warning message
+          auto it2 = component.parameters.find("initial_" + interface.name);
+          if (it2 != component.parameters.end())
+          {
+            states[index][i] = std::stod(it2->second);
+            print_hint = true;
+          }
+          else
+          {
+            print_hint = true;
+          }
+        }
+      }
+    }
+  }
+  if (print_hint)
+  {
+    RCUTILS_LOG_WARN_ONCE_NAMED(
+      "mock_generic_system",
+      "Parsing of optional initial interface values failed or uses a deprecated format. Add "
+      "initial values for every state interface in the ros2_control.xacro. For example: \n"
+      "<state_interface name=\"velocity\"> \n"
+      "  <param name=\"initial_value\">0.0</param> \n"
+      "</state_interface>");
+  }
+}
+
+template <typename InterfaceType>
+bool KukaMockHardwareInterface::populate_interfaces(
+  const std::vector<hardware_interface::ComponentInfo> & components,
+  std::vector<std::string> & interface_names, std::vector<std::vector<double>> & storage,
+  std::vector<InterfaceType> & target_interfaces, bool using_state_interfaces)
+{
+  for (auto i = 0u; i < components.size(); i++)
+  {
+    const auto & component = components[i];
+    const auto interfaces =
+      (using_state_interfaces) ? component.state_interfaces : component.command_interfaces;
+    for (const auto & interface : interfaces)
+    {
+      if (!get_interface(
+            component.name, interface_names, interface.name, i, storage, target_interfaces))
+      {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+}  // namespace kuka_mock_hardware_interface
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(
+  kuka_mock_hardware_interface::KukaMockHardwareInterface, hardware_interface::SystemInterface)

--- a/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
+++ b/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
@@ -4,7 +4,7 @@
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>mock_components/GenericSystem</plugin>
+          <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
+++ b/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
@@ -5,6 +5,8 @@
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
+          <param name="cycle_time_ms">4</param>
+          <param name="roundtrip_time_micro">4000</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_robot_descriptions/package.xml
+++ b/kuka_robot_descriptions/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>kuka_lbr_iiwa_support</exec_depend>
   <exec_depend>kuka_quantec_support</exec_depend>
   <exec_depend>kuka_resources</exec_depend>
+  <exec_depend>kuka_mock_hardware_interface</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
### Before submitting this PR into master please make sure:
If you added a new robot model:
- [ ] you extended the table of verified data in `README.md` with the new model
- [ ] you extended the CMakeLists.txt of the appropriate moveit configuration package with the new model
- [ ] you added a `test_<robot_model>.launch.py` and after launching the robot was visible in `rviz`
- [ ] you added a `<robot_model>_joint_limits.yaml` file in the `config` directory (to provide moveit support)

If you modified an already existing robot model:
- [ ] you checked and optionally updated the table of verified data in `README.md` with the changes
- [ ] you have run the `test_<robot_model>.launch.py` and the robot was visible in `rviz`

### Short description of the change
- Add KUKA mock hw to enable use_fake_hardware argument for drivers with custom state/cmd interfaces
- Modify timing of mock hw to perform "blocking read" with configurable cycle time