### PR TITLE
Add roundtrip time arg to xacros

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Additionally two hardware parameters are added:
 - To support similar timing behaviour as the actual robots, the mock hardware was extended with a blocking wait, so that the read function does not return immediately, but cyclically. The frequency of the loops is defined by the `cycle_time_ms` parameter. Default value is 4  [ms].
 - To be able to test whether a specific setup would fit into the roundtrip time enforced by a real robot, the `roundtrip_time_micro` parameter can be used. If the `write()` method is not called before the given timeout is exceeded (starting from the previous `read()` function), a warning message is logged (but the return value of the `write()` will be still SUCCESS). Default value is 0 [us], which means, that the roundrip time should not be monitored.
 
-The mock hardware was implemented in this repository to allow testing moveit without having to build the driver code.
+The mock hardware was implemented in this repository to allow testing moveit capabilities for the robots without having to build the driver code.
 
 ## Starting the move group server with mock hardware
 
@@ -128,4 +128,4 @@ ros2 launch kuka_lbr_iiwa_moveit_config moveit_planning_fake_hardware.launch.py
 ```
 A `robot_model` argument can be added after the command (e.g. `robot_model:=lbr_iisy11_r1300`). The default robot model is `lbr_iisy3_r760`
 
-These launch files are not using the actual driver implementation, they only start `rviz` the `move_group` server and a `ros2_control_node` with fake hardware and two controllers `joint_state_broadcaster` and `joint_trajectory_controller` The server will be able to accept planning requests from the plugin or from code. (An example how to create such a request from C++ code can be found in the `iiqka_moveit_example` package in the `kuka_drivers` repository.) To support hardwares with less performance, the update rate of the control node was reduced to 50 Hz for all robots.
+These launch files are not using the actual driver implementation, they only start `rviz` the `move_group` server and a `ros2_control_node` with fake hardware and two controllers `joint_state_broadcaster` and `joint_trajectory_controller` The server will be able to accept planning requests from the plugin or from code. (An example how to create such a request from C++ code can be found in the `iiqka_moveit_example` package in the `kuka_drivers` repository.)

--- a/kuka_agilus_support/urdf/kr10_r1100_2.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr10_r1100_2.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr10_r1100_2_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
   <xacro:arg name="prefix" default=""/>
@@ -13,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr10_r1100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_kr10_r1100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr10_r1100_2_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr10_r1100_2_macro.xacro
+++ b/kuka_agilus_support/urdf/kr10_r1100_2_macro.xacro
@@ -4,9 +4,9 @@
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
-  <xacro:macro name="kuka_kr10_r1100_2_robot" params="client_ip client_port prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_kr10_r1100_2_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr10_r1100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr10_r1100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" />
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">

--- a/kuka_agilus_support/urdf/kr6_r700_sixx.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr6_r700_sixx.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr6_r700_sixx_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
   <xacro:arg name="prefix" default=""/>
@@ -13,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr6_r700_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_kr6_r700_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr6_r700_sixx_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
@@ -4,9 +4,9 @@
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
-  <xacro:macro name="kuka_kr6_r700_sixx_robot" params="client_ip client_port prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_kr6_r700_sixx_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r700_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r700_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" />
     <link name="world"/>
     <link name="${prefix}base_link">
       <visual>

--- a/kuka_agilus_support/urdf/kr6_r900_sixx.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr6_r900_sixx.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr6_r900_sixx_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
   <xacro:arg name="prefix" default=""/>
@@ -13,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr6_r900_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_kr6_r900_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr6_r900_sixx_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
@@ -4,9 +4,9 @@
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
-  <xacro:macro name="kuka_kr6_r900_sixx_robot" params="client_ip client_port prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_kr6_r900_sixx_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r900_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r900_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" />
     <link name="world"/>
     <link name="${prefix}base_link">
       <visual>

--- a/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
+++ b/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_agilus_ros2_control" params="name client_ip client_port prefix use_fake_hardware">
+  <xacro:macro name="kuka_agilus_ros2_control" params="name client_ip client_port prefix use_fake_hardware roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
-          <param name="roundtrip_time_micro">4000</param>
+          <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
+++ b/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
@@ -25,13 +25,13 @@
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
         <state_interface name="position">
-          <param name="initial_value">0.0</param>
+          <param name="initial_value">-1.5708</param>
         </state_interface>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
         <state_interface name="position">
-          <param name="initial_value">0.0</param>
+          <param name="initial_value">1.5708</param>
         </state_interface>
       </joint>
       <joint name="${prefix}joint_4">

--- a/kuka_cybertech_support/urdf/kr16_r2010_2.urdf.xacro
+++ b/kuka_cybertech_support/urdf/kr16_r2010_2.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_cybertech_support)/urdf/kr16_r2010_2_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
   <xacro:arg name="prefix" default=""/>
@@ -13,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr16_r2010_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_kr16_r2010_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr16_r2010_2_robot>
 </robot>

--- a/kuka_cybertech_support/urdf/kr16_r2010_2_macro.xacro
+++ b/kuka_cybertech_support/urdf/kr16_r2010_2_macro.xacro
@@ -2,9 +2,9 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find kuka_cybertech_support)/urdf/kr_cybertech_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_cybertech_support)/urdf/kr_cybertech_transmission.xacro"/>
-  <xacro:macro name="kuka_kr16_r2010_2_robot" params="client_ip client_port prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_kr16_r2010_2_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_cybertech_ros2_control name="${prefix}kr16_r2010_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_cybertech_ros2_control name="${prefix}kr16_r2010_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" />
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>

--- a/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
+++ b/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_cybertech_ros2_control" params="name client_ip client_port prefix use_fake_hardware">
+  <xacro:macro name="kuka_cybertech_ros2_control" params="name client_ip client_port prefix use_fake_hardware roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
-          <param name="roundtrip_time_micro">4000</param>
+          <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
+++ b/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
@@ -25,13 +25,13 @@
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
         <state_interface name="position">
-          <param name="initial_value">0.0</param>
+          <param name="initial_value">-1.5708</param>
         </state_interface>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
         <state_interface name="position">
-          <param name="initial_value">0.0</param>
+          <param name="initial_value">1.5708</param>
         </state_interface>
       </joint>
       <joint name="${prefix}joint_4">

--- a/kuka_fortec_support/urdf/kr560_r3100_2.urdf.xacro
+++ b/kuka_fortec_support/urdf/kr560_r3100_2.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_fortec_support)/urdf/kr560_r3100_2_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
   <xacro:arg name="prefix" default=""/>
@@ -13,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr560_r3100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_kr560_r3100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr560_r3100_2_robot>
 </robot>

--- a/kuka_fortec_support/urdf/kr560_r3100_2_macro.xacro
+++ b/kuka_fortec_support/urdf/kr560_r3100_2_macro.xacro
@@ -2,9 +2,9 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find kuka_fortec_support)/urdf/kr_fortec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_fortec_support)/urdf/kr_fortec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr560_r3100_2_robot" params="client_ip client_port prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_kr560_r3100_2_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_fortec_ros2_control name="${prefix}kr560_r3100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_fortec_ros2_control name="${prefix}kr560_r3100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" />
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>

--- a/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
+++ b/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_fortec_ros2_control" params="name client_ip client_port prefix use_fake_hardware">
+  <xacro:macro name="kuka_fortec_ros2_control" params="name client_ip client_port prefix use_fake_hardware roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
-          <param name="roundtrip_time_micro">4000</param>
+          <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
+++ b/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
@@ -25,13 +25,13 @@
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
         <state_interface name="position">
-          <param name="initial_value">0.0</param>
+          <param name="initial_value">-1.5708</param>
         </state_interface>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
         <state_interface name="position">
-          <param name="initial_value">0.0</param>
+          <param name="initial_value">1.5708</param>
         </state_interface>
       </joint>
       <joint name="${prefix}joint_4">

--- a/kuka_iontec_support/urdf/kr70_r2100.urdf.xacro
+++ b/kuka_iontec_support/urdf/kr70_r2100.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_iontec_support)/urdf/kr70_r2100_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
   <xacro:arg name="prefix" default=""/>
@@ -13,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr70_r2100_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_kr70_r2100_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr70_r2100_robot>
 </robot>

--- a/kuka_iontec_support/urdf/kr70_r2100_macro.xacro
+++ b/kuka_iontec_support/urdf/kr70_r2100_macro.xacro
@@ -2,9 +2,9 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find kuka_iontec_support)/urdf/kr_iontec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_iontec_support)/urdf/kr_iontec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr70_r2100_robot" params="client_ip client_port prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_kr70_r2100_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_iontec_ros2_control name="${prefix}kr70_r2100" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_iontec_ros2_control name="${prefix}kr70_r2100" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" />
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>

--- a/kuka_iontec_support/urdf/kr_iontec_ros2_control.xacro
+++ b/kuka_iontec_support/urdf/kr_iontec_ros2_control.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_iontec_ros2_control" params="name client_ip client_port prefix use_fake_hardware">
+  <xacro:macro name="kuka_iontec_ros2_control" params="name client_ip client_port prefix use_fake_hardware roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
-          <param name="roundtrip_time_micro">4000</param>
+          <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_iontec_support/urdf/kr_iontec_ros2_control.xacro
+++ b/kuka_iontec_support/urdf/kr_iontec_ros2_control.xacro
@@ -25,13 +25,13 @@
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
         <state_interface name="position">
-          <param name="initial_value">0.0</param>
+          <param name="initial_value">-1.5708</param>
         </state_interface>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
         <state_interface name="position">
-          <param name="initial_value">0.0</param>
+          <param name="initial_value">1.5708</param>
         </state_interface>
       </joint>
       <joint name="${prefix}joint_4">

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy11_r1300.urdf.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy11_r1300.urdf.xacro
@@ -7,6 +7,7 @@
   <xacro:arg name="controller_ip" default="0.0.0.0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="qos_config_file" default=""/>
   <xacro:arg name="x" default="0"/>
   <xacro:arg name="y" default="0"/>
@@ -14,7 +15,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_lbr_iisy11_r1300_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" use_fake_hardware="$(arg use_fake_hardware)" qos_config_file="$(arg qos_config_file)">
+  <xacro:kuka_lbr_iisy11_r1300_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)" qos_config_file="$(arg qos_config_file)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_lbr_iisy11_r1300_robot>
 </robot>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy11_r1300_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy11_r1300_macro.xacro
@@ -4,7 +4,7 @@
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_transmission.xacro"/>
-  <xacro:macro name="kuka_lbr_iisy11_r1300_robot" params="prefix controller_ip client_ip use_fake_hardware qos_config_file *origin">
+  <xacro:macro name="kuka_lbr_iisy11_r1300_robot" params="prefix controller_ip client_ip use_fake_hardware roundtrip_time qos_config_file *origin">
     <!-- ros2 control instance -->
     <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy11_r1300" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
     <!-- links - main serial chain -->

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy11_r1300_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy11_r1300_macro.xacro
@@ -6,7 +6,7 @@
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_transmission.xacro"/>
   <xacro:macro name="kuka_lbr_iisy11_r1300_robot" params="prefix controller_ip client_ip use_fake_hardware qos_config_file *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy11_r1300" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" qos_config_file="${qos_config_file}"/>
+    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy11_r1300" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy15_r930.urdf.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy15_r930.urdf.xacro
@@ -7,6 +7,7 @@
   <xacro:arg name="controller_ip" default="0.0.0.0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="qos_config_file" default=""/>
   <xacro:arg name="x" default="0"/>
   <xacro:arg name="y" default="0"/>
@@ -14,7 +15,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_lbr_iisy15_r930_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" use_fake_hardware="$(arg use_fake_hardware)" qos_config_file="$(arg qos_config_file)">
+  <xacro:kuka_lbr_iisy15_r930_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)" qos_config_file="$(arg qos_config_file)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_lbr_iisy15_r930_robot>
 </robot>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy15_r930_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy15_r930_macro.xacro
@@ -6,7 +6,7 @@
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_transmission.xacro"/>
   <xacro:macro name="kuka_lbr_iisy15_r930_robot" params="prefix controller_ip client_ip use_fake_hardware qos_config_file *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy15_r930" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" qos_config_file="${qos_config_file}"/>
+    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy15_r930" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy15_r930_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy15_r930_macro.xacro
@@ -4,7 +4,7 @@
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_transmission.xacro"/>
-  <xacro:macro name="kuka_lbr_iisy15_r930_robot" params="prefix controller_ip client_ip use_fake_hardware qos_config_file *origin">
+  <xacro:macro name="kuka_lbr_iisy15_r930_robot" params="prefix controller_ip client_ip use_fake_hardware roundtrip_time qos_config_file *origin">
     <!-- ros2 control instance -->
     <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy15_r930" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
     <!-- links - main serial chain -->

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760.urdf.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760.urdf.xacro
@@ -7,6 +7,7 @@
   <xacro:arg name="controller_ip" default="0.0.0.0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="qos_config_file" default=""/>
   <xacro:arg name="x" default="0"/>
   <xacro:arg name="y" default="0"/>
@@ -14,7 +15,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_lbr_iisy3_r760_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" use_fake_hardware="$(arg use_fake_hardware)" qos_config_file="$(arg qos_config_file)">
+  <xacro:kuka_lbr_iisy3_r760_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)" qos_config_file="$(arg qos_config_file)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_lbr_iisy3_r760_robot>
 </robot>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760_macro.xacro
@@ -6,7 +6,7 @@
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_transmission.xacro"/>
   <xacro:macro name="kuka_lbr_iisy3_r760_robot" params="prefix controller_ip client_ip use_fake_hardware qos_config_file *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy3_r760" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" qos_config_file="${qos_config_file}"/>
+    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy3_r760" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760_macro.xacro
@@ -4,7 +4,7 @@
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_transmission.xacro"/>
-  <xacro:macro name="kuka_lbr_iisy3_r760_robot" params="prefix controller_ip client_ip use_fake_hardware qos_config_file *origin">
+  <xacro:macro name="kuka_lbr_iisy3_r760_robot" params="prefix controller_ip client_ip use_fake_hardware roundtrip_time qos_config_file *origin">
     <!-- ros2 control instance -->
     <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy3_r760" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
     <!-- links - main serial chain -->

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_lbr_iisy_ros2_control" params="name prefix client_ip controller_ip use_fake_hardware qos_config_file">
+  <xacro:macro name="kuka_lbr_iisy_ros2_control" params="name prefix client_ip controller_ip use_fake_hardware qos_config_file roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
-          <param name="roundtrip_time_micro">2500</param>
+          <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
@@ -49,7 +49,7 @@
         <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
-          <param name="initial_value">0.0</param>
+          <param name="initial_value">-1.5708</param>
         </state_interface>
         <state_interface name="effort">
           <param name="initial_value">0.0</param>
@@ -61,7 +61,7 @@
         <command_interface name="damping"/>
         <command_interface name="effort"/>
         <state_interface name="position">
-          <param name="initial_value">0.0</param>
+          <param name="initial_value">1.5708</param>
         </state_interface>
         <state_interface name="effort">
           <param name="initial_value">0.0</param>

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820.urdf.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa14_r820_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="x" default="0"/>
   <xacro:arg name="y" default="0"/>
   <xacro:arg name="z" default="0"/>
@@ -11,7 +12,7 @@
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
   <xacro:arg name="prefix" default=""/>
-  <xacro:kuka_lbr_iiwa14_r820_robot prefix="$(arg prefix)" io_access="false" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_lbr_iiwa14_r820_robot prefix="$(arg prefix)" io_access="false" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_lbr_iiwa14_r820_robot>
 </robot>

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820_macro.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa14_r820_macro.xacro
@@ -4,9 +4,9 @@
   <xacro:include filename="$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa_transmission.xacro"/>
-  <xacro:macro name="kuka_lbr_iiwa14_r820_robot" params="io_access prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_lbr_iiwa14_r820_robot" params="io_access prefix use_fake_hardware roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_lbr_iiwa_ros2_control name="${prefix}lbr_iiwa14_r820" prefix="${prefix}" io_access="${io_access}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_lbr_iiwa_ros2_control name="${prefix}lbr_iiwa14_r820" prefix="${prefix}" io_access="${io_access}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" />
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">

--- a/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control.xacro
+++ b/kuka_lbr_iiwa_support/urdf/lbr_iiwa_ros2_control.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_lbr_iiwa_ros2_control" params="name prefix io_access use_fake_hardware">
+  <xacro:macro name="kuka_lbr_iiwa_ros2_control" params="name prefix io_access use_fake_hardware roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">5</param>
-          <param name="roundtrip_time_micro">5000</param>
+          <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>

--- a/kuka_quantec_support/urdf/kr210_r2700_2.urdf.xacro
+++ b/kuka_quantec_support/urdf/kr210_r2700_2.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr210_r2700_2_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
   <xacro:arg name="prefix" default=""/>
@@ -13,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr210_r2700_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_kr210_r2700_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr210_r2700_2_robot>
 </robot>

--- a/kuka_quantec_support/urdf/kr210_r2700_2_macro.xacro
+++ b/kuka_quantec_support/urdf/kr210_r2700_2_macro.xacro
@@ -2,9 +2,9 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr210_r2700_2_robot" params="client_ip client_port prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_kr210_r2700_2_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r2700_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r2700_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" />
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>

--- a/kuka_quantec_support/urdf/kr210_r3100_2.urdf.xacro
+++ b/kuka_quantec_support/urdf/kr210_r3100_2.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr210_r3100_2_macro.xacro"/>
   <!-- Read additional arguments  -->
   <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
   <xacro:arg name="prefix" default=""/>
@@ -13,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr210_r3100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)">
+  <xacro:kuka_kr210_r3100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr210_r3100_2_robot>
 </robot>

--- a/kuka_quantec_support/urdf/kr210_r3100_2_macro.xacro
+++ b/kuka_quantec_support/urdf/kr210_r3100_2_macro.xacro
@@ -2,9 +2,9 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr210_r3100_2_robot" params="client_ip client_port prefix use_fake_hardware *origin">
+  <xacro:macro name="kuka_kr210_r3100_2_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r3100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r3100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" />
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>

--- a/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
+++ b/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
@@ -25,13 +25,13 @@
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
         <state_interface name="position">
-          <param name="initial_value">-1.570796</param>
+          <param name="initial_value">-1.5708</param>
         </state_interface>
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
         <state_interface name="position">
-          <param name="initial_value">1.570796</param>
+          <param name="initial_value">1.5708</param>
         </state_interface>
       </joint>
       <joint name="${prefix}joint_4">

--- a/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
+++ b/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_quantec_ros2_control" params="name client_ip client_port prefix use_fake_hardware">
+  <xacro:macro name="kuka_quantec_ros2_control" params="name client_ip client_port prefix use_fake_hardware roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
-          <param name="roundtrip_time_micro">4000</param>
+          <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>


### PR DESCRIPTION
### Before submitting this PR into master please make sure:
If you added a new robot model:
- [ ] you extended the table of verified data in `README.md` with the new model
- [ ] you extended the CMakeLists.txt of the appropriate moveit configuration package with the new model
- [ ] you added a `test_<robot_model>.launch.py` and after launching the robot was visible in `rviz`
- [ ] you added a `<robot_model>_joint_limits.yaml` file in the `config` directory (to provide moveit support)

If you modified an already existing robot model:
- [ ] you checked and optionally updated the table of verified data in `README.md` with the changes
- [ ] you have run the `test_<robot_model>.launch.py` and the robot was visible in `rviz`

### Short description of the change
Added roundtrip time argument to xacros, to be able to disable frequent warnings on non-RT systems