### PR TITLE
Migrating master to Jazzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ Collision meshes are provided for the robots to speed up collision avoidance and
 
 ### Joint limit configurations
 
-The support packages contain a joint limits file for every supported robot model, necessary time parametrization of MoveIt-planned paths. They contain the velocity limits also available in the URDF model and additional acceleration limits. Acceleration limits can never be global, these values are calculated from the worst-case ramp-up time to reach maximum velocity. The easiest way to modify the allowed velocities and accelerations is to change the velocity and acceleration scaling factors also available in the same configuration files. (The scaling factor can never be smaller than 1.)
-
+The support packages contain a joint limits file for every supported robot model, necessary time parametrization of MoveIt-planned paths. They contain the velocity limits also available in the URDF model and additional acceleration limits. Acceleration limits can never be global, these values are calculated from the worst-case ramp-up time to reach maximum velocity. The easiest way to modify the allowed velocities and accelerations is to change the velocity and acceleration scaling factors also available in the same configuration files. (The scaling factor can never be greater than 1.)
 
 ### Extending the models
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 This repository contains support packages that can be used with real KUKA robots as well as with simulations.
 
-Github CI
-------------
-[![Build Status](https://github.com/kroshu/kuka_robot_descriptions/workflows/CI/badge.svg?branch=main)](https://github.com/kroshu/kuka_robot_descriptions/actions)
+ROS2 Distro | Branch | Github CI
+------------ | -------------- | --------------
+**Jazzy** | [`master`](https://github.com/kroshu/kuka_robot_descriptions/tree/master) | [![Build Status](https://github.com/kroshu/kuka_robot_descriptions/actions/workflows/industrial_ci.yml/badge.svg?branch=master)](https://github.com/kroshu/kuka_robot_descriptions/actions)
+**Humble** | [`humble`](https://github.com/kroshu/kuka_robot_descriptions/tree/humble) | [![Build Status](https://github.com/kroshu/kuka_robot_descriptions/actions/workflows/industrial_ci.yml/badge.svg?branch=humble)](https://github.com/kroshu/kuka_robot_descriptions/actions)
 
 ## What is included?
 

--- a/kuka_lbr_iisy_moveit_config/config/chomp_planning.yaml
+++ b/kuka_lbr_iisy_moveit_config/config/chomp_planning.yaml
@@ -1,10 +1,14 @@
-planning_plugin: chomp_interface/CHOMPPlanner
-request_adapters: >-
-  default_planner_request_adapters/AddTimeOptimalParameterization
-  default_planner_request_adapters/FixWorkspaceBounds
-  default_planner_request_adapters/FixStartStateBounds
-  default_planner_request_adapters/FixStartStateCollision
-  default_planner_request_adapters/FixStartStatePathConstraints
+planning_plugins: 
+  - chomp_interface/CHOMPPlanner
+request_adapters:
+  - default_planning_request_adapters/ResolveConstraintFrames
+  - default_planning_request_adapters/ValidateWorkspaceBounds
+  - default_planning_request_adapters/CheckStartStateBounds
+  - default_planning_request_adapters/CheckStartStateCollision
+response_adapters:
+  - default_planning_response_adapters/AddTimeOptimalParameterization
+  - default_planning_response_adapters/ValidateSolution
+  - default_planning_response_adapters/DisplayMotionPath
 start_state_max_bounds_error: 0.1
 planning_time_limit: 10.0
 max_iterations: 200

--- a/kuka_lbr_iisy_moveit_config/config/chomp_planning.yaml
+++ b/kuka_lbr_iisy_moveit_config/config/chomp_planning.yaml
@@ -1,4 +1,4 @@
-planning_plugins: 
+planning_plugins:
   - chomp_interface/CHOMPPlanner
 request_adapters:
   - default_planning_request_adapters/ResolveConstraintFrames

--- a/kuka_lbr_iisy_moveit_config/config/ompl_planning.yaml
+++ b/kuka_lbr_iisy_moveit_config/config/ompl_planning.yaml
@@ -1,11 +1,12 @@
 planning_plugins:
   - ompl_interface/OMPLPlanner
-# The order of the elements in the adapter corresponds to the order they are processed by the motion planning pipeline.
 request_adapters:
   - default_planning_request_adapters/ResolveConstraintFrames
   - default_planning_request_adapters/ValidateWorkspaceBounds
   - default_planning_request_adapters/CheckStartStateBounds
   - default_planning_request_adapters/CheckStartStateCollision
+# To optionally use Ruckig for jerk-limited smoothing, add this line to the response adapters below
+# default_planning_response_adapters/AddRuckigTrajectorySmoothing
 response_adapters:
   - default_planning_response_adapters/AddTimeOptimalParameterization
   - default_planning_response_adapters/ValidateSolution
@@ -18,7 +19,16 @@ planner_configs:
     hybridize: 1  # Compute hybrid solution trajectories
     max_hybrid_paths: 36  # Number of hybrid paths generated per iteration
     num_planners: 8  # The number of default planners to use for planning
-    planners: "RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect"  # A comma-separated list of planner types (e.g., "PRM,EST,RRTConnect"Optionally, planner parameters can be passed to change the default:"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]"
+    # Optionally, planner parameters can be passed to change the default: "PRM[max_nearest_neighbors=5]", "EST[goal_bias=.5]", "RRT[range=10. goal_bias=.1]"
+    planners:
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
   SBLkConfigDefault:
     type: geometric::SBL
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()

--- a/kuka_lbr_iisy_moveit_config/config/ompl_planning.yaml
+++ b/kuka_lbr_iisy_moveit_config/config/ompl_planning.yaml
@@ -1,13 +1,15 @@
-planning_plugin: ompl_interface/OMPLPlanner
-# To optionally use Ruckig for jerk-limited smoothing, add this line to the request adapters below
-# default_planner_request_adapters/AddRuckigTrajectorySmoothing
-request_adapters: >-
-  default_planner_request_adapters/AddTimeOptimalParameterization
-  default_planner_request_adapters/ResolveConstraintFrames
-  default_planner_request_adapters/FixWorkspaceBounds
-  default_planner_request_adapters/FixStartStateBounds
-  default_planner_request_adapters/FixStartStateCollision
-  default_planner_request_adapters/FixStartStatePathConstraints
+planning_plugins:
+  - ompl_interface/OMPLPlanner
+# The order of the elements in the adapter corresponds to the order they are processed by the motion planning pipeline.
+request_adapters:
+  - default_planning_request_adapters/ResolveConstraintFrames
+  - default_planning_request_adapters/ValidateWorkspaceBounds
+  - default_planning_request_adapters/CheckStartStateBounds
+  - default_planning_request_adapters/CheckStartStateCollision
+response_adapters:
+  - default_planning_response_adapters/AddTimeOptimalParameterization
+  - default_planning_response_adapters/ValidateSolution
+  - default_planning_response_adapters/DisplayMotionPath
 start_state_max_bounds_error: 0.1
 planner_configs:
   APSConfigDefault:

--- a/kuka_lbr_iisy_moveit_config/config/stomp_planning.yaml
+++ b/kuka_lbr_iisy_moveit_config/config/stomp_planning.yaml
@@ -1,10 +1,14 @@
-planning_plugin: stomp_moveit/StompPlanner
-request_adapters: >-
-  default_planner_request_adapters/AddTimeOptimalParameterization
-  default_planner_request_adapters/FixWorkspaceBounds
-  default_planner_request_adapters/FixStartStateBounds
-  default_planner_request_adapters/FixStartStateCollision
-  default_planner_request_adapters/FixStartStatePathConstraints
+planning_plugins:
+  - stomp_moveit/StompPlanner
+request_adapters:
+  - default_planning_request_adapters/ResolveConstraintFrames
+  - default_planning_request_adapters/ValidateWorkspaceBounds
+  - default_planning_request_adapters/CheckStartStateBounds
+  - default_planning_request_adapters/CheckStartStateCollision
+response_adapters:
+  - default_planning_response_adapters/AddTimeOptimalParameterization
+  - default_planning_response_adapters/ValidateSolution
+  - default_planning_response_adapters/DisplayMotionPath
 
 stomp_moveit:
   num_timesteps: 60

--- a/kuka_lbr_iiwa_moveit_config/config/chomp_planning.yaml
+++ b/kuka_lbr_iiwa_moveit_config/config/chomp_planning.yaml
@@ -1,10 +1,14 @@
-planning_plugin: chomp_interface/CHOMPPlanner
-request_adapters: >-
-  default_planner_request_adapters/AddTimeOptimalParameterization
-  default_planner_request_adapters/FixWorkspaceBounds
-  default_planner_request_adapters/FixStartStateBounds
-  default_planner_request_adapters/FixStartStateCollision
-  default_planner_request_adapters/FixStartStatePathConstraints
+planning_plugins: 
+  - chomp_interface/CHOMPPlanner
+request_adapters:
+  - default_planning_request_adapters/ResolveConstraintFrames
+  - default_planning_request_adapters/ValidateWorkspaceBounds
+  - default_planning_request_adapters/CheckStartStateBounds
+  - default_planning_request_adapters/CheckStartStateCollision
+response_adapters:
+  - default_planning_response_adapters/AddTimeOptimalParameterization
+  - default_planning_response_adapters/ValidateSolution
+  - default_planning_response_adapters/DisplayMotionPath
 start_state_max_bounds_error: 0.1
 planning_time_limit: 10.0
 max_iterations: 200

--- a/kuka_lbr_iiwa_moveit_config/config/chomp_planning.yaml
+++ b/kuka_lbr_iiwa_moveit_config/config/chomp_planning.yaml
@@ -1,4 +1,4 @@
-planning_plugins: 
+planning_plugins:
   - chomp_interface/CHOMPPlanner
 request_adapters:
   - default_planning_request_adapters/ResolveConstraintFrames

--- a/kuka_lbr_iiwa_moveit_config/config/ompl_planning.yaml
+++ b/kuka_lbr_iiwa_moveit_config/config/ompl_planning.yaml
@@ -1,13 +1,16 @@
-planning_plugin: ompl_interface/OMPLPlanner
-# To optionally use Ruckig for jerk-limited smoothing, add this line to the request adapters below
-# default_planner_request_adapters/AddRuckigTrajectorySmoothing
-request_adapters: >-
-  default_planner_request_adapters/AddTimeOptimalParameterization
-  default_planner_request_adapters/ResolveConstraintFrames
-  default_planner_request_adapters/FixWorkspaceBounds
-  default_planner_request_adapters/FixStartStateBounds
-  default_planner_request_adapters/FixStartStateCollision
-  default_planner_request_adapters/FixStartStatePathConstraints
+planning_plugins:
+  - ompl_interface/OMPLPlanner
+request_adapters:
+  - default_planning_request_adapters/ResolveConstraintFrames
+  - default_planning_request_adapters/ValidateWorkspaceBounds
+  - default_planning_request_adapters/CheckStartStateBounds
+  - default_planning_request_adapters/CheckStartStateCollision
+# To optionally use Ruckig for jerk-limited smoothing, add this line to the response adapters below
+# default_planning_response_adapters/AddRuckigTrajectorySmoothing
+response_adapters:
+  - default_planning_response_adapters/AddTimeOptimalParameterization
+  - default_planning_response_adapters/ValidateSolution
+  - default_planning_response_adapters/DisplayMotionPath
 start_state_max_bounds_error: 0.1
 planner_configs:
   APSConfigDefault:
@@ -16,7 +19,16 @@ planner_configs:
     hybridize: 1  # Compute hybrid solution trajectories
     max_hybrid_paths: 36  # Number of hybrid paths generated per iteration
     num_planners: 8  # The number of default planners to use for planning
-    planners: "RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect"  # A comma-separated list of planner types (e.g., "PRM,EST,RRTConnect"Optionally, planner parameters can be passed to change the default:"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]"
+    # Optionally, planner parameters can be passed to change the default: "PRM[max_nearest_neighbors=5]", "EST[goal_bias=.5]", "RRT[range=10. goal_bias=.1]"
+    planners:
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
+      - RRTConnect
   SBLkConfigDefault:
     type: geometric::SBL
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()

--- a/kuka_lbr_iiwa_moveit_config/config/stomp_planning.yaml
+++ b/kuka_lbr_iiwa_moveit_config/config/stomp_planning.yaml
@@ -1,10 +1,14 @@
-planning_plugin: stomp_moveit/StompPlanner
-request_adapters: >-
-  default_planner_request_adapters/AddTimeOptimalParameterization
-  default_planner_request_adapters/FixWorkspaceBounds
-  default_planner_request_adapters/FixStartStateBounds
-  default_planner_request_adapters/FixStartStateCollision
-  default_planner_request_adapters/FixStartStatePathConstraints
+planning_plugins:
+  - stomp_moveit/StompPlanner
+request_adapters:
+  - default_planning_request_adapters/ResolveConstraintFrames
+  - default_planning_request_adapters/ValidateWorkspaceBounds
+  - default_planning_request_adapters/CheckStartStateBounds
+  - default_planning_request_adapters/CheckStartStateCollision
+response_adapters:
+  - default_planning_response_adapters/AddTimeOptimalParameterization
+  - default_planning_response_adapters/ValidateSolution
+  - default_planning_response_adapters/DisplayMotionPath
 
 stomp_moveit:
   num_timesteps: 60


### PR DESCRIPTION
### Before submitting this PR into master please make sure:
If you added a new robot model:
- [ ] you extended the table of verified data in `README.md` with the new model
- [ ] you extended the CMakeLists.txt of the appropriate moveit configuration package with the new model
- [ ] you added a `test_<robot_model>.launch.py` and after launching the robot was visible in `rviz`
- [ ] you added a `<robot_model>_joint_limits.yaml` file in the `config` directory (to provide moveit support)

If you modified an already existing robot model:
- [ ] you checked and optionally updated the table of verified data in `README.md` with the changes
- [ ] you have run the `test_<robot_model>.launch.py` and the robot was visible in `rviz`

### Short description of the change
Updated packages to work with ROS 2 Jazzy.
Created a [`humble`](https://github.com/kroshu/kuka_robot_descriptions/tree/humble) branch from the current master, which from now on will be responsible for ROS2 Humble support.