### PR TITLE
Use contoller config in moveit fake hardware launch only if defined

### DIFF
--- a/kuka_resources/launch/fake_hardware_planning_template.launch.py
+++ b/kuka_resources/launch/fake_hardware_planning_template.launch.py
@@ -94,14 +94,15 @@ def launch_setup(context, *args, **kwargs):
         arg_list = [
             controller_with_config[0],
             "-c",
-            controller_manager_node,
-            "-p",
-            controller_with_config[1],
+            controller_manager_node
         ]
+        if controller_with_config[1] is not None:
+            arg_list.append("-p")
+            arg_list.append(controller_with_config[1])
         return Node(package="controller_manager", executable="spawner", arguments=arg_list)
 
     controller_names_and_config = [
-        ("joint_state_broadcaster", []),
+        ("joint_state_broadcaster", None),
         ("joint_trajectory_controller", controller_config),
     ]
 

--- a/kuka_resources/launch/fake_hardware_planning_template.launch.py
+++ b/kuka_resources/launch/fake_hardware_planning_template.launch.py
@@ -91,11 +91,7 @@ def launch_setup(context, *args, **kwargs):
 
     # Spawn controllers
     def controller_spawner(controller_with_config):
-        arg_list = [
-            controller_with_config[0],
-            "-c",
-            controller_manager_node
-        ]
+        arg_list = [controller_with_config[0], "-c", controller_manager_node]
         if controller_with_config[1] is not None:
             arg_list.append("-p")
             arg_list.append(controller_with_config[1])


### PR DESCRIPTION
### Before submitting this PR into master please make sure:
If you added a new robot model:
- [ ] you extended the table of verified data in `README.md` with the new model
- [ ] you extended the CMakeLists.txt of the appropriate moveit configuration package with the new model
- [ ] you added a `test_<robot_model>.launch.py` and after launching the robot was visible in `rviz`
- [ ] you added a `<robot_model>_joint_limits.yaml` file in the `config` directory (to provide moveit support)

If you modified an already existing robot model:
- [ ] you checked and optionally updated the table of verified data in `README.md` with the changes
- [ ] you have run the `test_<robot_model>.launch.py` and the robot was visible in `rviz`

### Short description of the change
