### PR TITLE
Add Gazebo support for Humble

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,18 +90,18 @@ The following table shows what data is included for each robot in the support pa
 
 |Robot name | Robot family | Transformations | Joint position limits | Joint velocity limits | Joint effort limits | Inertial values | Simplified collision meshes|
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-|lbr_iisy3_r760| - | ✓ | ✓ | ✓ | ✓ | | ✓ |
+|lbr_iisy3_r760| - | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 |lbr_iisy11_r1300| - | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-|lbr_iisy15_r930| - | ✓ | ✓ | ✓ | ✓ | | ✓ |
+|lbr_iisy15_r930| - | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 |lbr_iiwa14_r820| - | ✓ | ✓ | ✓ | | | ✓ |
 |kr6_r700_sixx| agilus | ✓ | ✓ | ✓ | | | ✓ |
 |kr6_r900_sixx| agilus | ✓ | ✓ | ✓ | | | ✓ |
-|kr10_r1100_2| agilus | ✓ | ✓ | ✓ | ✓ | | ✓ |
+|kr10_r1100_2| agilus | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 |kr16_r2010_2| cybertech | ✓ | ✓ | ✓ | ✓ | | ✓ |
 |kr70_r2100| iontec | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-|kr210_r2700_2| quantec | ✓ | ✓ | ✓ | ✓ | | ✓ |
-|kr210_r3100_2| quantec | ✓ | ✓ | ✓ | ✓ | | ✓ |
-|kr560_r3100_2| fortec | ✓ | ✓ | ✓ | ✓ | | ✓ |
+|kr210_r2700_2| quantec | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+|kr210_r3100_2| quantec | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+|kr560_r3100_2| fortec | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 ## Custom mock hardware
 

--- a/kuka_agilus_support/CMakeLists.txt
+++ b/kuka_agilus_support/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(xacro REQUIRED)
 install(DIRECTORY config launch meshes urdf
   DESTINATION share/${PROJECT_NAME})
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.dsv")
+
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake)
   add_launch_test(test/test_kr_agilus.py)

--- a/kuka_agilus_support/kuka_agilus_support.dsv
+++ b/kuka_agilus_support/kuka_agilus_support.dsv
@@ -1,0 +1,1 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share

--- a/kuka_agilus_support/urdf/kr10_r1100_2.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr10_r1100_2.urdf.xacro
@@ -3,7 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr10_r1100_2_macro.xacro"/>
   <!-- Read additional arguments  -->
-  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
@@ -14,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr10_r1100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr10_r1100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr10_r1100_2_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr10_r1100_2_macro.xacro
+++ b/kuka_agilus_support/urdf/kr10_r1100_2_macro.xacro
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="kr10_r1100_2">
   <!-- include helper xacros -->
+  <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
-  <xacro:macro name="kuka_kr10_r1100_2_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
+  <xacro:macro name="kuka_kr10_r1100_2_robot" params="client_ip client_port prefix mode roundtrip_time *origin">
+    <!-- gazebo -->
+    <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml" />
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr10_r1100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr10_r1100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">
@@ -16,6 +19,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.16209200415615" ixy="0.0" ixz="0.0" iyy="0.10881181598555635" iyz="0.0" izz="0.18461591505869543"/>
+        <mass value="1.6916E1"/>
+        <origin rpy="1.6165592773339865 -1.221289277333065 3.10031147437779" xyz="-0.03713348309292976 2.6602033577676952E-5 0.10863850792149446"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_agilus_support/meshes/kr10_r1100_2/visual/base_link.stl"/>
@@ -31,6 +39,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.07406183855390855" ixy="0.0" ixz="0.0" iyy="0.0890478351825312" iyz="0.0" izz="0.11039570662759429"/>
+        <mass value="8.4159999999999986E0"/>
+        <origin rpy="1.304519343134156 -0.9428616016893947 -1.4226510948637578" xyz="0.006410408745247152 -0.01626805370722434 -0.10658893773764262"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_agilus_support/meshes/kr10_r1100_2/visual/link_1.stl"/>
@@ -46,6 +59,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.8751595055066254" ixy="0.0" ixz="0.0" iyy="0.09215049446198915" iyz="0.0" izz="0.9157117764876721"/>
+        <mass value="1.78369E1"/>
+        <origin rpy="1.9524873827550635 -1.5422358773344043 -0.3902815673307173" xyz="0.191160133767639 -0.004651344123698628 -0.07520541854245974"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_agilus_support/meshes/kr10_r1100_2/visual/link_2.stl"/>
@@ -61,6 +79,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.04469381119929391" ixy="0.0" ixz="0.0" iyy="0.018969508933922696" iyz="0.0" izz="0.0498412586885908"/>
+        <mass value="6.075E0"/>
+        <origin rpy="-2.676930368410595 -1.321895859309871 1.1860920267202666" xyz="0.04386106995884774 -0.012506995884773664 -0.06825142386831277"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_agilus_support/meshes/kr10_r1100_2/visual/link_3.stl"/>
@@ -76,6 +99,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.012301413884477554" ixy="0.0" ixz="0.0" iyy="0.08469612193319441" iyz="0.0" izz="0.08739834186747329"/>
+        <mass value="5.1623807059999995E0"/>
+        <origin rpy="-2.228094247436686 -1.5326119469267911 2.179783954730353" xyz="0.0013191433102012267 0.008607757626765767 -0.14098161935749579"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_agilus_support/meshes/kr10_r1100_2/visual/link_4.stl"/>
@@ -91,6 +119,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.0017317756133102904" ixy="0.0" ixz="0.0" iyy="0.002219500805440681" iyz="0.0" izz="0.002467090055442975"/>
+        <mass value="1.6128E0"/>
+        <origin rpy="1.567898714902774 -0.8611716764868309 -3.100280255900493" xyz="0.009320696924603175 7.83482142857143E-4 -0.026462549603174602"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_agilus_support/meshes/kr10_r1100_2/visual/link_5.stl"/>
@@ -106,6 +139,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="1.83698267603013E-4" ixy="0.0" ixz="0.0" iyy="1.8213621766783165E-4" iyz="0.0" izz="2.9589000000000004E-4"/>
+        <mass value="7.34E-1"/>
+        <origin rpy="0.0 -0.0 1.223427188696551" xyz="0.0 0.0 -0.011764604904632152"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_agilus_support/meshes/kr10_r1100_2/visual/link_6.stl"/>

--- a/kuka_agilus_support/urdf/kr6_r700_sixx.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr6_r700_sixx.urdf.xacro
@@ -3,7 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr6_r700_sixx_macro.xacro"/>
   <!-- Read additional arguments  -->
-  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
@@ -14,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr6_r700_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr6_r700_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr6_r700_sixx_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
@@ -19,11 +19,6 @@
         </geometry>
         <xacro:material_kuka_pedestal/>
       </visual>
-      <inertial>
-        <inertia ixx="0.16209200415615" ixy="0.0" ixz="0.0" iyy="0.10881181598555635" iyz="0.0" izz="0.18461591505869543"/>
-        <mass value="1.6916E1"/>
-        <origin rpy="1.6165592773339865 -1.221289277333065 3.10031147437779" xyz="-0.03713348309292976 2.6602033577676952E-5 0.10863850792149446"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -39,11 +34,6 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
-      <inertial>
-        <inertia ixx="0.07406183855390855" ixy="0.0" ixz="0.0" iyy="0.0890478351825312" iyz="0.0" izz="0.11039570662759429"/>
-        <mass value="8.4159999999999986E0"/>
-        <origin rpy="1.304519343134156 -0.9428616016893947 -1.4226510948637578" xyz="0.006410408745247152 -0.01626805370722434 -0.10658893773764262"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -59,11 +49,6 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
-      <inertial>
-        <inertia ixx="0.27913939628518236" ixy="0.0" ixz="0.0" iyy="0.08120682412128737" iyz="0.0" izz="0.31885940962560827"/>
-        <mass value="1.55659E1"/>
-        <origin rpy="-1.3903732489969973 -1.5149954424356888 -0.1998085283039958" xyz="0.09688971405443952 -0.004085391785890956 -0.07157586711979391"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -79,11 +64,6 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
-      <inertial>
-        <inertia ixx="0.016743444555446362" ixy="0.0" ixz="0.0" iyy="0.025482537016456808" iyz="0.0" izz="0.02822390996140248"/>
-        <mass value="5.303E0"/>
-        <origin rpy="2.3581203240627353 -0.21894199177335477 -3.004285178078088" xyz="0.022228738449934005 -0.011136149349424855 -0.06927623986422779"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -99,11 +79,6 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
-      <inertial>
-        <inertia ixx="0.010531272787231831" ixy="0.0" ixz="0.0" iyy="0.03425565311920862" iyz="0.0" izz="0.037359032949440756"/>
-        <mass value="4.6129999999999995E0"/>
-        <origin rpy="-2.0540104905408416 -1.5266176566842766 2.01813464445371" xyz="1.0969000650336042E-4 0.010267591588987646 -0.09163862995881207"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -119,11 +94,6 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
-      <inertial>
-        <inertia ixx="0.0017317756133102904" ixy="0.0" ixz="0.0" iyy="0.002219500805440681" iyz="0.0" izz="0.002467090055442975"/>
-        <mass value="1.6128E0"/>
-        <origin rpy="1.567898714902774 -0.8611716764868309 -3.100280255900493" xyz="0.009320696924603175 7.83482142857143E-4 -0.026462549603174602"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -139,11 +109,6 @@
         </geometry>
         <xacro:material_kuka_pedestal/>
       </visual>
-      <inertial>
-        <inertia ixx="1.83698267603013E-4" ixy="0.0" ixz="0.0" iyy="1.8213621766783165E-4" iyz="0.0" izz="2.9589000000000004E-4"/>
-        <mass value="7.34E-1"/>
-        <origin rpy="0.0 -0.0 1.223427188696551" xyz="0.0 0.0 -0.011764604904632152"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>

--- a/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
@@ -1,12 +1,15 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_constants.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
-  <xacro:macro name="kuka_kr6_r700_sixx_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
+  <xacro:macro name="kuka_kr6_r700_sixx_robot" params="client_ip client_port prefix mode roundtrip_time *origin">
+    <!-- gazebo -->
+    <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml" />
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r700_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r700_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <visual>
@@ -16,6 +19,11 @@
         </geometry>
         <xacro:material_kuka_pedestal/>
       </visual>
+      <inertial>
+        <inertia ixx="0.16209200415615" ixy="0.0" ixz="0.0" iyy="0.10881181598555635" iyz="0.0" izz="0.18461591505869543"/>
+        <mass value="1.6916E1"/>
+        <origin rpy="1.6165592773339865 -1.221289277333065 3.10031147437779" xyz="-0.03713348309292976 2.6602033577676952E-5 0.10863850792149446"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -31,6 +39,11 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
+      <inertial>
+        <inertia ixx="0.07406183855390855" ixy="0.0" ixz="0.0" iyy="0.0890478351825312" iyz="0.0" izz="0.11039570662759429"/>
+        <mass value="8.4159999999999986E0"/>
+        <origin rpy="1.304519343134156 -0.9428616016893947 -1.4226510948637578" xyz="0.006410408745247152 -0.01626805370722434 -0.10658893773764262"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -46,6 +59,11 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
+      <inertial>
+        <inertia ixx="0.27913939628518236" ixy="0.0" ixz="0.0" iyy="0.08120682412128737" iyz="0.0" izz="0.31885940962560827"/>
+        <mass value="1.55659E1"/>
+        <origin rpy="-1.3903732489969973 -1.5149954424356888 -0.1998085283039958" xyz="0.09688971405443952 -0.004085391785890956 -0.07157586711979391"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -61,6 +79,11 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
+      <inertial>
+        <inertia ixx="0.016743444555446362" ixy="0.0" ixz="0.0" iyy="0.025482537016456808" iyz="0.0" izz="0.02822390996140248"/>
+        <mass value="5.303E0"/>
+        <origin rpy="2.3581203240627353 -0.21894199177335477 -3.004285178078088" xyz="0.022228738449934005 -0.011136149349424855 -0.06927623986422779"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -76,6 +99,11 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
+      <inertial>
+        <inertia ixx="0.010531272787231831" ixy="0.0" ixz="0.0" iyy="0.03425565311920862" iyz="0.0" izz="0.037359032949440756"/>
+        <mass value="4.6129999999999995E0"/>
+        <origin rpy="-2.0540104905408416 -1.5266176566842766 2.01813464445371" xyz="1.0969000650336042E-4 0.010267591588987646 -0.09163862995881207"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -91,6 +119,11 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
+      <inertial>
+        <inertia ixx="0.0017317756133102904" ixy="0.0" ixz="0.0" iyy="0.002219500805440681" iyz="0.0" izz="0.002467090055442975"/>
+        <mass value="1.6128E0"/>
+        <origin rpy="1.567898714902774 -0.8611716764868309 -3.100280255900493" xyz="0.009320696924603175 7.83482142857143E-4 -0.026462549603174602"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -106,6 +139,11 @@
         </geometry>
         <xacro:material_kuka_pedestal/>
       </visual>
+      <inertial>
+        <inertia ixx="1.83698267603013E-4" ixy="0.0" ixz="0.0" iyy="1.8213621766783165E-4" iyz="0.0" izz="2.9589000000000004E-4"/>
+        <mass value="7.34E-1"/>
+        <origin rpy="0.0 -0.0 1.223427188696551" xyz="0.0 0.0 -0.011764604904632152"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>

--- a/kuka_agilus_support/urdf/kr6_r900_sixx.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr6_r900_sixx.urdf.xacro
@@ -3,7 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr6_r900_sixx_macro.xacro"/>
   <!-- Read additional arguments  -->
-  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
@@ -14,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr6_r900_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr6_r900_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr6_r900_sixx_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
@@ -19,11 +19,6 @@
         </geometry>
         <xacro:material_kuka_pedestal/>
       </visual>
-      <inertial>
-        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
-        <mass value="6.22E0"/>
-        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -39,11 +34,6 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
-      <inertial>
-        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.1"/>
-        <mass value="1.7555E1"/>
-        <origin rpy="0.0 -0.0 0.0" xyz="0.010625999999999998 -0.005681 -0.236731"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -59,11 +49,6 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
-      <inertial>
-        <inertia ixx="0.508" ixy="0.0" ixz="0.0" iyy="0.043" iyz="0.0" izz="0.522"/>
-        <mass value="1.1835E1"/>
-        <origin rpy="0.0 -1.5707963267948966 -1.5707963267948968" xyz="0.223874 0.0 0.007783"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -79,11 +64,6 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
-      <inertial>
-        <inertia ixx="0.007999999999999991" ixy="0.0" ixz="0.0" iyy="0.059999999999999984" iyz="0.0" izz="0.063"/>
-        <mass value="3.71E0"/>
-        <origin rpy="0.0 -0.0 3.141592653589793" xyz="0.019573999999999994 0.0 0.0014259999999999995"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -99,11 +79,6 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
-      <inertial>
-        <inertia ixx="0.356" ixy="0.0" ixz="0.0" iyy="0.004" iyz="0.0" izz="0.359"/>
-        <mass value="8.502E0"/>
-        <origin rpy="1.5707963267948966 -0.0 1.5707963267948966" xyz="0.0 0.0 -0.193625"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -119,11 +94,6 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
-      <inertial>
-        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
-        <mass value="1.0E-6"/>
-        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -139,11 +109,6 @@
         </geometry>
         <xacro:material_kuka_pedestal/>
       </visual>
-      <inertial>
-        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
-        <mass value="1.0E-6"/>
-        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
-      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>

--- a/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
@@ -1,12 +1,15 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_constants.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
-  <xacro:macro name="kuka_kr6_r900_sixx_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
+  <xacro:macro name="kuka_kr6_r900_sixx_robot" params="client_ip client_port prefix mode roundtrip_time *origin">
+    <!-- gazebo -->
+    <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml" />
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r900_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r900_sixx" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <visual>
@@ -16,6 +19,11 @@
         </geometry>
         <xacro:material_kuka_pedestal/>
       </visual>
+      <inertial>
+        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        <mass value="6.22E0"/>
+        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -31,6 +39,11 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
+      <inertial>
+        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.1"/>
+        <mass value="1.7555E1"/>
+        <origin rpy="0.0 -0.0 0.0" xyz="0.010625999999999998 -0.005681 -0.236731"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -46,6 +59,11 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
+      <inertial>
+        <inertia ixx="0.508" ixy="0.0" ixz="0.0" iyy="0.043" iyz="0.0" izz="0.522"/>
+        <mass value="1.1835E1"/>
+        <origin rpy="0.0 -1.5707963267948966 -1.5707963267948968" xyz="0.223874 0.0 0.007783"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -61,6 +79,11 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
+      <inertial>
+        <inertia ixx="0.007999999999999991" ixy="0.0" ixz="0.0" iyy="0.059999999999999984" iyz="0.0" izz="0.063"/>
+        <mass value="3.71E0"/>
+        <origin rpy="0.0 -0.0 3.141592653589793" xyz="0.019573999999999994 0.0 0.0014259999999999995"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -76,6 +99,11 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
+      <inertial>
+        <inertia ixx="0.356" ixy="0.0" ixz="0.0" iyy="0.004" iyz="0.0" izz="0.359"/>
+        <mass value="8.502E0"/>
+        <origin rpy="1.5707963267948966 -0.0 1.5707963267948966" xyz="0.0 0.0 -0.193625"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -91,6 +119,11 @@
         </geometry>
         <xacro:material_kuka_orange/>
       </visual>
+      <inertial>
+        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        <mass value="1.0E-6"/>
+        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -106,6 +139,11 @@
         </geometry>
         <xacro:material_kuka_pedestal/>
       </visual>
+      <inertial>
+        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        <mass value="1.0E-6"/>
+        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
+      </inertial>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>

--- a/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
+++ b/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_agilus_ros2_control" params="name client_ip client_port prefix use_fake_hardware roundtrip_time">
+  <xacro:macro name="kuka_agilus_ros2_control" params="name client_ip client_port prefix mode roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
-        <xacro:if value="${use_fake_hardware}">
+        <xacro:if value="${mode == 'mock'}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
           <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
-        <xacro:unless value="${use_fake_hardware}">
+        <xacro:unless value="${mode != 'hardware'}">
           <plugin>kuka_kss_rsi_driver::KukaRSIHardwareInterface</plugin>
           <param name="client_ip">${client_ip}</param>
           <param name="client_port">${client_port}</param>
         </xacro:unless>
+        <xacro:if value="${mode == 'gazebo'}">
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+        </xacro:if>
       </hardware>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>

--- a/kuka_cybertech_support/CMakeLists.txt
+++ b/kuka_cybertech_support/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(xacro REQUIRED)
 install(DIRECTORY config launch meshes urdf
   DESTINATION share/${PROJECT_NAME})
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.dsv")
+
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake)
   add_launch_test(test/test_kr_cybertech.py)

--- a/kuka_cybertech_support/kuka_cybertech_support.dsv
+++ b/kuka_cybertech_support/kuka_cybertech_support.dsv
@@ -1,0 +1,1 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share

--- a/kuka_cybertech_support/urdf/kr16_r2010_2.urdf.xacro
+++ b/kuka_cybertech_support/urdf/kr16_r2010_2.urdf.xacro
@@ -3,7 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_cybertech_support)/urdf/kr16_r2010_2_macro.xacro"/>
   <!-- Read additional arguments  -->
-  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
@@ -14,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr16_r2010_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr16_r2010_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr16_r2010_2_robot>
 </robot>

--- a/kuka_cybertech_support/urdf/kr16_r2010_2_macro.xacro
+++ b/kuka_cybertech_support/urdf/kr16_r2010_2_macro.xacro
@@ -16,11 +16,6 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
-      <inertial>
-        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
-        <mass value="6.52116E1"/>
-        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
-      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/base_link.stl"/>
@@ -35,11 +30,6 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
-      <inertial>
-        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="1.50392348"/>
-        <mass value="8.4207E1"/>
-        <origin rpy="0.0 -0.0 1.695151321341658" xyz="0.050473 0.0052792 -0.1312334"/>
-      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_1.stl"/>
@@ -54,11 +44,6 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
-      <inertial>
-        <inertia ixx="9.85967888" ixy="0.0" ixz="0.0" iyy="0.91499458" iyz="0.0" izz="10.23026596"/>
-        <mass value="6.1775E1"/>
-        <origin rpy="0.0 -1.5707963267948966 -1.5707963267948968" xyz="0.4020773724 0.0 -0.0731476"/>
-      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_2.stl"/>
@@ -73,11 +58,6 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
-      <inertial>
-        <inertia ixx="0.34836069" ixy="0.0" ixz="0.0" iyy="1.0268737" iyz="0.0" izz="1.13887402"/>
-        <mass value="3.5648E1"/>
-        <origin rpy="0.0 -0.0 0.0" xyz="0.10935396937 0.0 0.045030299999999995"/>
-      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_3.stl"/>
@@ -92,11 +72,6 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
-      <inertial>
-        <inertia ixx="0.64549911" ixy="0.0" ixz="0.0" iyy="0.04236472" iyz="0.0" izz="0.6665241"/>
-        <mass value="1.64280001E1"/>
-        <origin rpy="1.5707963267948966 -0.0 1.5707963267948966" xyz="0.0 0.0 -0.32342865478"/>
-      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_4.stl"/>
@@ -111,11 +86,6 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
-      <inertial>
-        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
-        <mass value="1.0E-6"/>
-        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
-      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_5.stl"/>
@@ -130,11 +100,6 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
-      <inertial>
-        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
-        <mass value="1.0E-6"/>
-        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
-      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_6.stl"/>

--- a/kuka_cybertech_support/urdf/kr16_r2010_2_macro.xacro
+++ b/kuka_cybertech_support/urdf/kr16_r2010_2_macro.xacro
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
   <xacro:include filename="$(find kuka_cybertech_support)/urdf/kr_cybertech_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_cybertech_support)/urdf/kr_cybertech_transmission.xacro"/>
-  <xacro:macro name="kuka_kr16_r2010_2_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
+  <xacro:macro name="kuka_kr16_r2010_2_robot" params="client_ip client_port prefix mode roundtrip_time *origin">
+    <!-- gazebo -->
+    <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml" />
     <!-- ros2 control instance -->
-    <xacro:kuka_cybertech_ros2_control name="${prefix}kr16_r2010_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_cybertech_ros2_control name="${prefix}kr16_r2010_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>
@@ -13,6 +16,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        <mass value="6.52116E1"/>
+        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/base_link.stl"/>
@@ -27,6 +35,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="1.50392348"/>
+        <mass value="8.4207E1"/>
+        <origin rpy="0.0 -0.0 1.695151321341658" xyz="0.050473 0.0052792 -0.1312334"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_1.stl"/>
@@ -41,6 +54,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="9.85967888" ixy="0.0" ixz="0.0" iyy="0.91499458" iyz="0.0" izz="10.23026596"/>
+        <mass value="6.1775E1"/>
+        <origin rpy="0.0 -1.5707963267948966 -1.5707963267948968" xyz="0.4020773724 0.0 -0.0731476"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_2.stl"/>
@@ -55,6 +73,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.34836069" ixy="0.0" ixz="0.0" iyy="1.0268737" iyz="0.0" izz="1.13887402"/>
+        <mass value="3.5648E1"/>
+        <origin rpy="0.0 -0.0 0.0" xyz="0.10935396937 0.0 0.045030299999999995"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_3.stl"/>
@@ -69,6 +92,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.64549911" ixy="0.0" ixz="0.0" iyy="0.04236472" iyz="0.0" izz="0.6665241"/>
+        <mass value="1.64280001E1"/>
+        <origin rpy="1.5707963267948966 -0.0 1.5707963267948966" xyz="0.0 0.0 -0.32342865478"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_4.stl"/>
@@ -83,6 +111,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        <mass value="1.0E-6"/>
+        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_5.stl"/>
@@ -97,6 +130,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        <mass value="1.0E-6"/>
+        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_cybertech_support/meshes/kr16_r2010_2/visual/link_6.stl"/>

--- a/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
+++ b/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_cybertech_ros2_control" params="name client_ip client_port prefix use_fake_hardware roundtrip_time">
+  <xacro:macro name="kuka_cybertech_ros2_control" params="name client_ip client_port prefix mode roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
-        <xacro:if value="${use_fake_hardware}">
+        <xacro:if value="${mode == 'mock'}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
           <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
-        <xacro:unless value="${use_fake_hardware}">
+        <xacro:unless value="${mode != 'hardware'}">
           <plugin>kuka_kss_rsi_driver::KukaRSIHardwareInterface</plugin>
           <param name="client_ip">${client_ip}</param>
           <param name="client_port">${client_port}</param>
         </xacro:unless>
+        <xacro:if value="${mode == 'gazebo'}">
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+        </xacro:if>
       </hardware>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>

--- a/kuka_fortec_support/CMakeLists.txt
+++ b/kuka_fortec_support/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(xacro REQUIRED)
 install(DIRECTORY config launch meshes urdf
   DESTINATION share/${PROJECT_NAME})
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.dsv")
+
   if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake)
   add_launch_test(test/test_kr_fortec.py)

--- a/kuka_fortec_support/kuka_fortec_support.dsv
+++ b/kuka_fortec_support/kuka_fortec_support.dsv
@@ -1,0 +1,1 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share

--- a/kuka_fortec_support/urdf/kr560_r3100_2.urdf.xacro
+++ b/kuka_fortec_support/urdf/kr560_r3100_2.urdf.xacro
@@ -3,7 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_fortec_support)/urdf/kr560_r3100_2_macro.xacro"/>
   <!-- Read additional arguments  -->
-  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
@@ -14,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr560_r3100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr560_r3100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr560_r3100_2_robot>
 </robot>

--- a/kuka_fortec_support/urdf/kr560_r3100_2_macro.xacro
+++ b/kuka_fortec_support/urdf/kr560_r3100_2_macro.xacro
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
   <xacro:include filename="$(find kuka_fortec_support)/urdf/kr_fortec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_fortec_support)/urdf/kr_fortec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr560_r3100_2_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
+  <xacro:macro name="kuka_kr560_r3100_2_robot" params="client_ip client_port prefix mode roundtrip_time *origin">
+    <!-- gazebo -->
+    <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml" />
     <!-- ros2 control instance -->
-    <xacro:kuka_fortec_ros2_control name="${prefix}kr560_r3100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_fortec_ros2_control name="${prefix}kr560_r3100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>
@@ -13,6 +16,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="35.410866659826" ixy="0.0" ixz="0.0" iyy="34.5547429413375" iyz="0.0" izz="38.9749152422865"/>
+        <mass value="4.3839E2"/>
+        <origin rpy="-0.26345077947988915 -0.011417952338033863 -1.5831162104095253" xyz="-0.0219634111179543 2.66337735806023E-4 0.290824658865394"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_fortec_support/meshes/kr560_r3100_2/visual/base_link.dae"/>
@@ -27,6 +35,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="68.8871727481765" ixy="0.0" ixz="0.0" iyy="31.9479323362134" iyz="0.0" izz="84.5563373850467"/>
+        <mass value="5.5748E2"/>
+        <origin rpy="-1.8734135274052497 -1.508489219626719 0.30671025878674923" xyz="0.0812269789050728 0.00860667378201908 -0.29662668257157204"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_fortec_support/meshes/kr560_r3100_2/visual/link_1.dae"/>
@@ -41,6 +54,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="344.9055856506" ixy="0.0" ixz="0.0" iyy="45.4306396522043" iyz="0.0" izz="376.577425687136"/>
+        <mass value="7.4023E2"/>
+        <origin rpy="-1.4188791588206504 -1.5562308152773727 3.0008589795117246" xyz="0.673327322588925 -0.006679975683233591 0.022081825378598603"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_fortec_support/meshes/kr560_r3100_2/visual/link_2.dae"/>
@@ -55,6 +73,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="6.30840213271945" ixy="0.0" ixz="0.0" iyy="26.687628198328" iyz="0.0" izz="29.5636589044743"/>
+        <mass value="2.41307E2"/>
+        <origin rpy="0.028058985026686887 -0.003311222914120114 -0.07508596727782266" xyz="0.129307355539367 -0.12237728273757201 -0.005238577401690441"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_fortec_support/meshes/kr560_r3100_2/visual/link_3.dae"/>
@@ -69,6 +92,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.693678008600892" ixy="0.0" ixz="0.0" iyy="2.78506557610754" iyz="0.0" izz="2.86251005408283"/>
+        <mass value="9.7442E1"/>
+        <origin rpy="1.570932272091058 -1.2743253802401948 -1.570766714386286" xyz="-5.43869794830743E-7 0.042293334372276704 -0.18193497897866"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_fortec_support/meshes/kr560_r3100_2/visual/link_4.dae"/>
@@ -83,6 +111,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="1.10203832546012" ixy="0.0" ixz="0.0" iyy="0.783938692397306" iyz="0.0" izz="1.20828474699799"/>
+        <mass value="5.36088E1"/>
+        <origin rpy="-1.5642278602027897 -0.8175710147649964 -0.011709797778755686" xyz="0.06813413576091991 -4.9894728477414005E-5 -0.0893390051226664"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_fortec_support/meshes/kr560_r3100_2/visual/link_5.dae"/>
@@ -97,6 +130,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.154627253223927" ixy="0.0" ixz="0.0" iyy="0.154759872890913" iyz="0.0" izz="0.18961138268388"/>
+        <mass value="3.202E1"/>
+        <origin rpy="0.0020471651340902924 7.476904024900575E-5 -1.5692303732486164" xyz="-4.86570893191755E-5 -2.5301686445971304E-6 -0.0203013397876327"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_fortec_support/meshes/kr560_r3100_2/visual/link_6.dae"/>

--- a/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
+++ b/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_fortec_ros2_control" params="name client_ip client_port prefix use_fake_hardware roundtrip_time">
+  <xacro:macro name="kuka_fortec_ros2_control" params="name client_ip client_port prefix mode roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
-        <xacro:if value="${use_fake_hardware}">
+        <xacro:if value="${mode == 'mock'}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
           <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
-        <xacro:unless value="${use_fake_hardware}">
+        <xacro:unless value="${mode != 'hardware'}">
           <plugin>kuka_kss_rsi_driver::KukaRSIHardwareInterface</plugin>
           <param name="client_ip">${client_ip}</param>
           <param name="client_port">${client_port}</param>
         </xacro:unless>
+        <xacro:if value="${mode == 'gazebo'}">
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+        </xacro:if>
       </hardware>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>

--- a/kuka_gazebo/.vscode/c_cpp_properties.json
+++ b/kuka_gazebo/.vscode/c_cpp_properties.json
@@ -1,0 +1,18 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "/opt/ros/humble/include/**",
+                "/usr/include/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "linux-clang-x64"
+        }
+    ],
+    "version": 4
+}

--- a/kuka_gazebo/CMakeLists.txt
+++ b/kuka_gazebo/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.8)
+project(kuka_gazebo)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake REQUIRED)
+find_package(moveit_ros_planning_interface REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+
+include_directories(include)
+
+add_executable(gazebo_moveit_example src/gazebo_lbr_iisy3_r760_moveit_example.cpp)
+ament_target_dependencies(gazebo_moveit_example
+  moveit_ros_planning_interface
+  moveit_visual_tools
+)
+
+install(TARGETS
+  gazebo_moveit_example
+  EXPORT export_${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  DIRECTORY gazebo launch world
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/kuka_gazebo/gazebo/kuka_gazebo.xacro
+++ b/kuka_gazebo/gazebo/kuka_gazebo.xacro
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <xacro:macro name="kuka_gazebo" params="controller_config_package controller_config_path">
+        <!-- ros_control-plugin -->
+        <gazebo>
+            <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
+                <robot_param>robot_description</robot_param>
+                <robot_param_node>robot_state_publisher</robot_param_node>
+                <parameters>$(find ${controller_config_package})/${controller_config_path}</parameters>
+            </plugin>
+        </gazebo>
+    </xacro:macro>
+</robot>

--- a/kuka_gazebo/include/kuka_gazebo/moveit_example.hpp
+++ b/kuka_gazebo/include/kuka_gazebo/moveit_example.hpp
@@ -1,0 +1,120 @@
+#include <math.h>
+
+#include <memory>
+#include <rclcpp/parameter.hpp>
+#include <string>
+#include <vector>
+
+#include "geometry_msgs/msg/vector3.hpp"
+#include "moveit/move_group_interface/move_group_interface.h"
+#include "moveit/planning_scene_interface/planning_scene_interface.h"
+#include "moveit_msgs/msg/collision_object.hpp"
+#include "moveit_visual_tools/moveit_visual_tools.h"
+#include "rclcpp/rclcpp.hpp"
+
+class MoveitExample : public rclcpp::Node {
+public:
+  MoveitExample() : rclcpp::Node("moveit_example") {}
+
+  void initialize() {
+    this->set_parameter(rclcpp::Parameter("use_sim_time", true));
+    move_group_interface_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(
+      shared_from_this(), PLANNING_GROUP);
+
+    moveit_visual_tools_ = std::make_shared<moveit_visual_tools::MoveItVisualTools>(
+      shared_from_this(), "world", rviz_visual_tools::RVIZ_MARKER_TOPIC,
+      move_group_interface_->getRobotModel());
+
+    moveit_visual_tools_->deleteAllMarkers();
+    moveit_visual_tools_->loadRemoteControl();
+    moveit_visual_tools_->trigger();
+
+    planning_scene_diff_publisher_ =
+      this->create_publisher<moveit_msgs::msg::PlanningScene>("planning_scene", 10);
+
+    move_group_interface_->setMaxVelocityScalingFactor(0.1);
+    move_group_interface_->setMaxAccelerationScalingFactor(0.1);
+  }
+
+  moveit_msgs::msg::RobotTrajectory::SharedPtr planToPosition(const std::vector<double> & joint_pos) {
+    move_group_interface_->setJointValueTarget(joint_pos);
+
+    moveit::planning_interface::MoveGroupInterface::Plan plan;
+    RCLCPP_INFO(LOGGER, "Sending planning request");
+    if (!move_group_interface_->plan(plan)) {
+      RCLCPP_INFO(LOGGER, "Planning failed");
+      return nullptr;
+    } else {
+      RCLCPP_INFO(LOGGER, "Planning successful");
+      return std::make_shared<moveit_msgs::msg::RobotTrajectory>(plan.trajectory_);
+    }
+  }
+
+  moveit_msgs::msg::RobotTrajectory::SharedPtr planToPoint(
+    const Eigen::Isometry3d & pose,
+    const std::string & planning_pipeline = "pilz_industrial_motion_planner",
+    const std::string & planner_id = "PTP") {
+
+    // Create planning request using pilz industrial motion planner
+    move_group_interface_->setPlanningPipelineId(planning_pipeline);
+    move_group_interface_->setPlannerId(planner_id);
+    move_group_interface_->setPoseTarget(pose);
+
+    moveit::planning_interface::MoveGroupInterface::Plan plan;
+    RCLCPP_INFO(LOGGER, "Sending planning request");
+    if (!move_group_interface_->plan(plan))
+    {
+      RCLCPP_INFO(LOGGER, "Planning failed");
+      return nullptr;
+    }
+    else
+    {
+      RCLCPP_INFO(LOGGER, "Planning successful");
+      return std::make_shared<moveit_msgs::msg::RobotTrajectory>(plan.trajectory_);
+    }
+  }
+
+  moveit_msgs::msg::RobotTrajectory::SharedPtr planStraightPathAlongY(
+    const std::string & planning_pipeline = "pilz_industrial_motion_planner",
+    const std::string & planner_id = "PTP") {
+
+    // Create planning request using pilz industrial motion planner
+    move_group_interface_->setPlanningPipelineId(planning_pipeline);
+    move_group_interface_->setPlannerId(planner_id);
+
+    auto current_pose = move_group_interface_->getCurrentPose();
+    std::vector<geometry_msgs::msg::Pose> waypoints;
+    waypoints.push_back(current_pose.pose);
+
+    geometry_msgs::msg::Pose end_pose = current_pose.pose;
+    end_pose.position.y -= 1.0;
+    waypoints.push_back(end_pose);
+
+    moveit_msgs::msg::RobotTrajectory trajectory;
+    RCLCPP_INFO(LOGGER, "Sending planning request");
+    double fraction = move_group_interface_->computeCartesianPath(waypoints, 0.05, 0.0, trajectory);
+    if (fraction == -1.0) {
+      RCLCPP_INFO(LOGGER, "Planning failed");
+      return nullptr;
+    } else {
+      RCLCPP_INFO(LOGGER, "Planning successful");
+      return std::make_shared<moveit_msgs::msg::RobotTrajectory>(trajectory);
+    }
+  }
+
+  void addBreakPoint() {
+    moveit_visual_tools_->trigger();
+    moveit_visual_tools_->prompt("Press 'Next' in the RvizVisualToolsGui window to execute");
+  }
+
+  std::shared_ptr<moveit::planning_interface::MoveGroupInterface> moveGroupInterface() {
+    return move_group_interface_;
+  }
+
+protected:
+  std::shared_ptr<moveit::planning_interface::MoveGroupInterface> move_group_interface_;
+  rclcpp::Publisher<moveit_msgs::msg::PlanningScene>::SharedPtr planning_scene_diff_publisher_;
+  std::shared_ptr<moveit_visual_tools::MoveItVisualTools> moveit_visual_tools_;
+  const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_basic_plan");
+  const std::string PLANNING_GROUP = "manipulator";
+};

--- a/kuka_gazebo/launch/gazebo.launch.py
+++ b/kuka_gazebo/launch/gazebo.launch.py
@@ -1,0 +1,174 @@
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration
+from launch_ros.actions import Node, LifecycleNode
+from launch_ros.substitutions import FindPackageShare
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+import os
+
+def launch_setup(context, *args, **kwargs):
+    world = LaunchConfiguration("gz_world")
+    robot_model = LaunchConfiguration("robot_model")
+    robot_family_path = LaunchConfiguration("robot_family_support")
+    ns = LaunchConfiguration("namespace")
+    x = LaunchConfiguration("x")
+    y = LaunchConfiguration("y")
+    z = LaunchConfiguration("z")
+    roll = LaunchConfiguration("roll")
+    pitch = LaunchConfiguration("pitch")
+    yaw = LaunchConfiguration("yaw")
+    if ns.perform(context) == "":
+        tf_prefix = ""
+    else:
+        tf_prefix = ns.perform(context) + "_"
+
+    # Get URDF via xacro
+    robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            PathJoinSubstitution(
+                [
+                    FindPackageShare(robot_family_path.perform(context)),
+                    "urdf",
+                    robot_model.perform(context) + ".urdf.xacro",
+                ]
+            ),
+            " ",
+            "mode:=",
+            "gazebo",
+            " ",
+            "prefix:=",
+            tf_prefix,
+            " ",
+            "x:=",
+            x,
+            " ",
+            "y:=",
+            y,
+            " ",
+            "z:=",
+            z,
+            " ",
+            "roll:=",
+            roll,
+            " ",
+            "pitch:=",
+            pitch,
+            " ",
+            "yaw:=",
+            yaw,
+        ],
+        on_stderr="capture",
+    )
+
+    # Get URDF via xacro
+    robot_description = {"robot_description": robot_description_content}
+
+    robot_state_publisher = Node(
+        namespace=ns,
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="both",
+        parameters=[robot_description, {"use_sim_time": True, "mode": "gazebo"},],
+    )
+
+    # Gazebo
+    world_path = os.path.join(
+        get_package_share_directory("kuka_gazebo"), world.perform(context)
+    )
+    gazebo_ld = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("ros_gz_sim"),
+                    "launch",
+                    "gz_sim.launch.py",
+                ]
+            ),
+        ),
+        launch_arguments={"gz_args": [world_path, " -r -v1"]}.items(),
+    )
+
+    label = ["-x", "-y", "-z", "-R", "-P", "-Y"]
+    tf = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    tf = [str(x) for x in tf]
+    gazebo_robot_node = Node(
+        package="ros_gz_sim",
+        executable="create",
+        arguments=[
+            "-topic",
+            "robot_description",
+            "-name",
+            robot_model,
+            "-allow_renaming",
+        ] + [item for pair in zip(label, tf) for item in pair],
+        output="screen",
+    )
+
+    gazebo_bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        arguments=["/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock"],
+        output="screen",
+    )
+
+    # Spawn controllers
+    def controller_spawner(controller_name, param_file=None, activate=False):
+        arg_list = [
+            controller_name,
+            "-c",
+            "controller_manager",
+            "-n",
+            ns,
+        ]
+
+        # Add param-file if it's provided
+        if param_file:
+            arg_list.extend(["--param-file", param_file])
+
+        if not activate:
+            arg_list.append("--inactive")
+
+        return Node(package="controller_manager", executable="spawner", arguments=arg_list)
+
+    controllers = {
+        "joint_state_broadcaster": None,
+        "joint_trajectory_controller": None,
+    }
+
+    controller_spawners = [
+        controller_spawner(name, param_file, True) for name, param_file in controllers.items()
+    ]
+
+    nodes_to_start = [
+        robot_state_publisher,
+        gazebo_ld,
+        gazebo_robot_node,
+        gazebo_bridge,
+    ] + controller_spawners
+
+    return nodes_to_start
+
+
+def generate_launch_description():
+    launch_arguments = []
+    launch_arguments.append(DeclareLaunchArgument("robot_model", default_value="lbr_iisy3_r760"))
+    launch_arguments.append(DeclareLaunchArgument("robot_family_support", default_value="kuka_lbr_iisy_support"))
+    launch_arguments.append(DeclareLaunchArgument("namespace", default_value=""))
+    launch_arguments.append(DeclareLaunchArgument("x", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("y", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("z", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("roll", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("pitch", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("yaw", default_value="0"))
+    launch_arguments.append(
+        DeclareLaunchArgument(
+            name="gz_world",
+            default_value="world/empty_world.sdf",
+            description="The world to be loaded by Gazebo.",
+        )
+    )
+    return LaunchDescription(launch_arguments + [OpaqueFunction(function=launch_setup)])

--- a/kuka_gazebo/package.xml
+++ b/kuka_gazebo/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>kuka_gazebo</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="sanyi.komaromi@gmail.com">rosdeveloper</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/kuka_gazebo/src/gazebo_lbr_iisy3_r760_moveit_example.cpp
+++ b/kuka_gazebo/src/gazebo_lbr_iisy3_r760_moveit_example.cpp
@@ -1,0 +1,39 @@
+#include <math.h>
+
+#include <memory>
+#include <rclcpp/parameter_value.hpp>
+
+#include "kuka_gazebo/moveit_example.hpp"
+
+int main(int argc, char * argv[]) {
+  // Setup
+  // Initialize ROS and create the Node
+  rclcpp::init(argc, argv);
+  auto const example_node = std::make_shared<MoveitExample>();
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(example_node);
+  std::thread([&executor]() { executor.spin(); }).detach();
+
+  example_node->initialize();
+  example_node->addBreakPoint();
+
+  // Go to correct position for the example
+  auto init_trajectory = example_node->planToPosition(
+    std::vector<double>{-0.7037, -0.8217, 1.3433, -0.8246, -0.0358, 0.0243});
+  if (init_trajectory != nullptr) {
+    example_node->moveGroupInterface()->execute(*init_trajectory);
+  }
+
+  example_node->addBreakPoint();
+
+  auto planned_trajectory =
+    example_node->planStraightPathAlongY("ompl", "");
+  if (planned_trajectory != nullptr) {
+    example_node->addBreakPoint();
+    example_node->moveGroupInterface()->execute(*planned_trajectory);
+  }
+
+  // Shutdown ROS
+  rclcpp::shutdown();
+  return 0;
+}

--- a/kuka_gazebo/world/box.sdf
+++ b/kuka_gazebo/world/box.sdf
@@ -1,0 +1,108 @@
+<sdf version='1.9'>
+  <world name='empty'>
+    <physics name='1ms' type='ignored'>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+    </physics>
+    <plugin name='gz::sim::systems::Physics' filename='ignition-gazebo-physics-system'/>
+    <plugin name='gz::sim::systems::UserCommands' filename='ignition-gazebo-user-commands-system'/>
+    <plugin name='gz::sim::systems::SceneBroadcaster' filename='ignition-gazebo-scene-broadcaster-system'/>
+    <plugin name='gz::sim::systems::Contact' filename='ignition-gazebo-contact-system'/>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+    <scene>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>true</shadows>
+    </scene>
+    <model name='ground_plane'>
+      <static>true</static>
+      <link name='link'>
+        <collision name='collision'>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode/>
+            </friction>
+            <bounce/>
+            <contact/>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <pose>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <enable_wind>false</enable_wind>
+      </link>
+      <pose>0 0 0 0 -0 0</pose>
+      <self_collide>false</self_collide>
+    </model>
+    <model name="test_box">
+        <pose>0.4 0 0.1 0 0 0</pose>
+        <link name="box_link">
+            <collision name="box_collision">
+                <geometry>
+                    <box>
+                        <size>0.20 0.20 0.20</size>
+                    </box>
+                </geometry>
+            </collision>
+            <visual name="box_visual">
+                <geometry>
+                    <box>
+                        <size>0.20 0.20 0.20</size>
+                    </box>
+                </geometry>
+            </visual>
+        </link>
+    </model>
+    <light name='sun' type='directional'>
+        <pose>0 0 10 0 -0 0</pose>
+        <cast_shadows>true</cast_shadows>
+        <intensity>1</intensity>
+        <direction>-0.5 0.1 -0.9</direction>
+        <diffuse>0.8 0.8 0.8 1</diffuse>
+        <specular>0.2 0.2 0.2 1</specular>
+        <attenuation>
+            <range>1000</range>
+            <linear>0.01</linear>
+            <constant>0.90000000000000002</constant>
+            <quadratic>0.001</quadratic>
+        </attenuation>
+        <spot>
+            <inner_angle>0</inner_angle>
+            <outer_angle>0</outer_angle>
+            <falloff>0</falloff>
+        </spot>
+    </light>
+  </world>
+</sdf>

--- a/kuka_gazebo/world/empty_world.sdf
+++ b/kuka_gazebo/world/empty_world.sdf
@@ -1,0 +1,89 @@
+<sdf version='1.9'>
+  <world name='empty'>
+    <physics name='1ms' type='ignored'>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+    </physics>
+    <plugin name='gz::sim::systems::Physics' filename='ignition-gazebo-physics-system'/>
+    <plugin name='gz::sim::systems::UserCommands' filename='ignition-gazebo-user-commands-system'/>
+    <plugin name='gz::sim::systems::SceneBroadcaster' filename='ignition-gazebo-scene-broadcaster-system'/>
+    <plugin name='gz::sim::systems::Contact' filename='ignition-gazebo-contact-system'/>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+    <scene>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>true</shadows>
+    </scene>
+    <model name='ground_plane'>
+      <static>true</static>
+      <link name='link'>
+        <collision name='collision'>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode/>
+            </friction>
+            <bounce/>
+            <contact/>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <pose>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <enable_wind>false</enable_wind>
+      </link>
+      <pose>0 0 0 0 -0 0</pose>
+      <self_collide>false</self_collide>
+    </model>
+    <light name='sun' type='directional'>
+      <pose>0 0 10 0 -0 0</pose>
+      <cast_shadows>true</cast_shadows>
+      <intensity>1</intensity>
+      <direction>-0.5 0.1 -0.9</direction>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <linear>0.01</linear>
+        <constant>0.90000000000000002</constant>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+  </world>
+</sdf>

--- a/kuka_iontec_support/CMakeLists.txt
+++ b/kuka_iontec_support/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(xacro REQUIRED)
 install(DIRECTORY config launch meshes urdf
   DESTINATION share/${PROJECT_NAME})
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.dsv")
+
   if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake)
   add_launch_test(test/test_kr_iontec.py)

--- a/kuka_iontec_support/kuka_iontec_support.dsv
+++ b/kuka_iontec_support/kuka_iontec_support.dsv
@@ -1,0 +1,1 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share

--- a/kuka_iontec_support/urdf/kr70_r2100.urdf.xacro
+++ b/kuka_iontec_support/urdf/kr70_r2100.urdf.xacro
@@ -3,7 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_iontec_support)/urdf/kr70_r2100_macro.xacro"/>
   <!-- Read additional arguments  -->
-  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
@@ -14,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr70_r2100_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr70_r2100_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr70_r2100_robot>
 </robot>

--- a/kuka_iontec_support/urdf/kr70_r2100_macro.xacro
+++ b/kuka_iontec_support/urdf/kr70_r2100_macro.xacro
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
   <xacro:include filename="$(find kuka_iontec_support)/urdf/kr_iontec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_iontec_support)/urdf/kr_iontec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr70_r2100_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
+  <xacro:macro name="kuka_kr70_r2100_robot" params="client_ip client_port prefix mode roundtrip_time *origin">
+    <!-- gazebo -->
+    <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml" />
     <!-- ros2 control instance -->
-    <xacro:kuka_iontec_ros2_control name="${prefix}kr70_r2100" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_iontec_ros2_control name="${prefix}kr70_r2100" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>
@@ -13,6 +16,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="3.21771450042138" ixy="0.0" ixz="0.0" iyy="2.20944166758376" iyz="0.0" izz="3.52194780966785"/>
+        <mass value="1.1102E2"/>
+        <origin rpy="-0.09552224276473971 0.005165689953881887 1.5692512343174831" xyz="-0.0353407754502021 3.24880558618159E-4 0.169880117603822"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_iontec_support/meshes/kr70_r2100/visual/base_link.dae"/>

--- a/kuka_iontec_support/urdf/kr_iontec_ros2_control.xacro
+++ b/kuka_iontec_support/urdf/kr_iontec_ros2_control.xacro
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_iontec_ros2_control" params="name client_ip client_port prefix use_fake_hardware roundtrip_time">
+  <xacro:macro name="kuka_iontec_ros2_control" params="name client_ip client_port prefix mode roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
-        <xacro:if value="${use_fake_hardware}">
+        <xacro:if value="${mode == 'mock'}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
           <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
-        <xacro:unless value="${use_fake_hardware}">
+        <xacro:unless value="${mode != 'hardware'}">
           <plugin>kuka_kss_rsi_driver::KukaRSIHardwareInterface</plugin>
           <param name="client_ip">${client_ip}</param>
           <param name="client_port">${client_port}</param>
         </xacro:unless>
+        <xacro:if value="${mode == 'gazebo'}">
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+        </xacro:if>
       </hardware>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>

--- a/kuka_kr_moveit_config/CMakeLists.txt
+++ b/kuka_kr_moveit_config/CMakeLists.txt
@@ -13,8 +13,8 @@ set(supported_robots
   kr10_r1100_2
   kr16_r2010_2
   kr70_r2100
-  kr210-r2700_2
-  kr210-r3100_2
+  kr210_r2700_2
+  kr210_r3100_2
   kr560_r3100_2
 )
 

--- a/kuka_kr_moveit_config/launch/moveit_planning_gazebo.launch.py
+++ b/kuka_kr_moveit_config/launch/moveit_planning_gazebo.launch.py
@@ -1,0 +1,106 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+from moveit_configs_utils import MoveItConfigsBuilder
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
+
+def launch_setup(context, *args, **kwargs):
+    robot_model = LaunchConfiguration("robot_model")
+    robot_family_path = LaunchConfiguration("robot_family_support")
+    ns = LaunchConfiguration("namespace")
+    x = LaunchConfiguration("x")
+    y = LaunchConfiguration("y")
+    z = LaunchConfiguration("z")
+    roll = LaunchConfiguration("roll")
+    pitch = LaunchConfiguration("pitch")
+    yaw = LaunchConfiguration("yaw")
+
+    if ns.perform(context) == "":
+        tf_prefix = ""
+    else:
+        tf_prefix = ns.perform(context) + "_"
+
+    moveit_config = (
+        MoveItConfigsBuilder("kuka_kr")
+        .robot_description(
+            file_path=get_package_share_directory(robot_family_path.perform(context))
+            + f"/urdf/{robot_model.perform(context)}.urdf.xacro",
+            mappings={
+                "x": x.perform(context),
+                "y": y.perform(context),
+                "z": z.perform(context),
+                "roll": roll.perform(context),
+                "pitch": pitch.perform(context),
+                "yaw": yaw.perform(context),
+                "prefix": tf_prefix,
+            },
+        )
+        .robot_description_semantic(
+            f"urdf/{robot_model.perform(context)}_arm.srdf"
+        )
+        .robot_description_kinematics(file_path="config/kinematics.yaml")
+        .trajectory_execution(file_path="config/moveit_controllers.yaml")
+        .planning_scene_monitor(
+            publish_robot_description=True, publish_robot_description_semantic=True
+        )
+        .joint_limits(
+            file_path=get_package_share_directory(robot_family_path.perform(context))
+            + f"/config/{robot_model.perform(context)}_joint_limits.yaml"
+        )
+        .to_moveit_configs()
+    )
+
+    rviz_config_file = (
+        get_package_share_directory("kuka_resources") + "/config/planning_6_axis.rviz"
+    )
+
+    robot_description_kinematics = {
+        "robot_description_kinematics": {
+            "manipulator": {"kinematics_solver": "kdl_kinematics_plugin/KDLKinematicsPlugin"}
+        }
+    }
+
+    move_group_server = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="screen",
+        parameters=[
+            moveit_config.to_dict(), 
+            {"publish_planning_scene_hz": 30.0},
+            {"allow_trajectory_execution": True},
+            {"use_sim_time": True}, 
+            {"publish_planning_scene": True},
+            {"publish_state_updates": True},
+            {"publish_transforms_updates": True},
+        ],
+    )
+
+    rviz = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_file, "--ros-args", "--log-level", "error"],
+        parameters=[
+            robot_description_kinematics,
+        ],
+    )
+
+    to_start = [move_group_server, rviz]
+
+    return to_start
+
+
+def generate_launch_description():
+    launch_arguments = []
+    launch_arguments.append(DeclareLaunchArgument("robot_model", default_value="kr70_r2100"))
+    launch_arguments.append(DeclareLaunchArgument("robot_family_support", default_value="kuka_iontec_support"))
+    launch_arguments.append(DeclareLaunchArgument("namespace", default_value=""))
+    launch_arguments.append(DeclareLaunchArgument("x", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("y", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("z", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("roll", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("pitch", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("yaw", default_value="0"))
+    return LaunchDescription(launch_arguments + [OpaqueFunction(function=launch_setup)])

--- a/kuka_lbr_iisy_moveit_config/launch/moveit_planning_gazebo.launch.py
+++ b/kuka_lbr_iisy_moveit_config/launch/moveit_planning_gazebo.launch.py
@@ -1,0 +1,106 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+from moveit_configs_utils import MoveItConfigsBuilder
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
+
+def launch_setup(context, *args, **kwargs):
+    robot_model = LaunchConfiguration("robot_model")
+    robot_family_path = LaunchConfiguration("robot_family_support")
+    ns = LaunchConfiguration("namespace")
+    x = LaunchConfiguration("x")
+    y = LaunchConfiguration("y")
+    z = LaunchConfiguration("z")
+    roll = LaunchConfiguration("roll")
+    pitch = LaunchConfiguration("pitch")
+    yaw = LaunchConfiguration("yaw")
+
+    if ns.perform(context) == "":
+        tf_prefix = ""
+    else:
+        tf_prefix = ns.perform(context) + "_"
+
+    moveit_config = (
+        MoveItConfigsBuilder("kuka_lbr_iisy")
+        .robot_description(
+            file_path=get_package_share_directory(robot_family_path.perform(context))
+            + f"/urdf/{robot_model.perform(context)}.urdf.xacro",
+            mappings={
+                "x": x.perform(context),
+                "y": y.perform(context),
+                "z": z.perform(context),
+                "roll": roll.perform(context),
+                "pitch": pitch.perform(context),
+                "yaw": yaw.perform(context),
+                "prefix": tf_prefix,
+            },
+        )
+        .robot_description_semantic(
+            f"urdf/{robot_model.perform(context)}.srdf"
+        )
+        .robot_description_kinematics(file_path="config/kinematics.yaml")
+        .trajectory_execution(file_path="config/moveit_controllers.yaml")
+        .planning_scene_monitor(
+            publish_robot_description=True, publish_robot_description_semantic=True
+        )
+        .joint_limits(
+            file_path=get_package_share_directory(robot_family_path.perform(context))
+            + f"/config/{robot_model.perform(context)}_joint_limits.yaml"
+        )
+        .to_moveit_configs()
+    )
+
+    rviz_config_file = (
+        get_package_share_directory("kuka_resources") + "/config/planning_6_axis.rviz"
+    )
+
+    robot_description_kinematics = {
+        "robot_description_kinematics": {
+            "manipulator": {"kinematics_solver": "kdl_kinematics_plugin/KDLKinematicsPlugin"}
+        }
+    }
+
+    move_group_server = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="screen",
+        parameters=[
+            moveit_config.to_dict(), 
+            {"publish_planning_scene_hz": 30.0},
+            {"allow_trajectory_execution": True},
+            {"use_sim_time": True}, 
+            {"publish_planning_scene": True},
+            {"publish_state_updates": True},
+            {"publish_transforms_updates": True},
+        ],
+    )
+
+    rviz = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config_file, "--ros-args", "--log-level", "error"],
+        parameters=[
+            robot_description_kinematics,
+        ],
+    )
+
+    to_start = [move_group_server, rviz]
+
+    return to_start
+
+
+def generate_launch_description():
+    launch_arguments = []
+    launch_arguments.append(DeclareLaunchArgument("robot_model", default_value="lbr_iisy3_r760"))
+    launch_arguments.append(DeclareLaunchArgument("robot_family_support", default_value="kuka_lbr_iisy_support"))
+    launch_arguments.append(DeclareLaunchArgument("namespace", default_value=""))
+    launch_arguments.append(DeclareLaunchArgument("x", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("y", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("z", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("roll", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("pitch", default_value="0"))
+    launch_arguments.append(DeclareLaunchArgument("yaw", default_value="0"))
+    return LaunchDescription(launch_arguments + [OpaqueFunction(function=launch_setup)])

--- a/kuka_lbr_iisy_support/CMakeLists.txt
+++ b/kuka_lbr_iisy_support/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(xacro REQUIRED)
 install(DIRECTORY launch meshes urdf config
   DESTINATION share/${PROJECT_NAME})
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.dsv")
 
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake)

--- a/kuka_lbr_iisy_support/kuka_lbr_iisy_support.dsv
+++ b/kuka_lbr_iisy_support/kuka_lbr_iisy_support.dsv
@@ -1,0 +1,1 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy11_r1300.urdf.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy11_r1300.urdf.xacro
@@ -6,7 +6,7 @@
   <xacro:arg name="prefix" default=""/>
   <xacro:arg name="controller_ip" default="0.0.0.0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
-  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="qos_config_file" default=""/>
   <xacro:arg name="x" default="0"/>
@@ -15,7 +15,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_lbr_iisy11_r1300_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)" qos_config_file="$(arg qos_config_file)">
+  <xacro:kuka_lbr_iisy11_r1300_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)" qos_config_file="$(arg qos_config_file)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_lbr_iisy11_r1300_robot>
 </robot>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy11_r1300_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy11_r1300_macro.xacro
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="lbr_iisy11_r1300">
   <!-- include helper xacros -->
+  <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_transmission.xacro"/>
-  <xacro:macro name="kuka_lbr_iisy11_r1300_robot" params="prefix controller_ip client_ip use_fake_hardware roundtrip_time qos_config_file *origin">
+  <xacro:macro name="kuka_lbr_iisy11_r1300_robot" params="prefix controller_ip client_ip mode roundtrip_time qos_config_file *origin">
+    <!-- gazebo -->
+    <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml" />
     <!-- ros2 control instance -->
-    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy11_r1300" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
+    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy11_r1300" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" mode="${mode}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">
@@ -16,6 +19,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+        <mass value="8.666E0"/>
+        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_lbr_iisy_support/meshes/lbr_iisy11_r1300/visual/base_link.stl"/>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy15_r930.urdf.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy15_r930.urdf.xacro
@@ -6,7 +6,7 @@
   <xacro:arg name="prefix" default=""/>
   <xacro:arg name="controller_ip" default="0.0.0.0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
-  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="qos_config_file" default=""/>
   <xacro:arg name="x" default="0"/>
@@ -15,7 +15,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_lbr_iisy15_r930_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)" qos_config_file="$(arg qos_config_file)">
+  <xacro:kuka_lbr_iisy15_r930_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)" qos_config_file="$(arg qos_config_file)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_lbr_iisy15_r930_robot>
 </robot>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy15_r930_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy15_r930_macro.xacro
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="lbr_iisy15_r930">
   <!-- include helper xacros -->
+  <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_transmission.xacro"/>
-  <xacro:macro name="kuka_lbr_iisy15_r930_robot" params="prefix controller_ip client_ip use_fake_hardware roundtrip_time qos_config_file *origin">
+  <xacro:macro name="kuka_lbr_iisy15_r930_robot" params="prefix controller_ip client_ip mode roundtrip_time qos_config_file *origin">
+    <!-- gazebo -->
+    <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml" />
     <!-- ros2 control instance -->
-    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy15_r930" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
+    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy15_r930" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" mode="${mode}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">
@@ -16,6 +19,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+        <mass value="8.666E0"/>
+        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 0.0"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_lbr_iisy_support/meshes/lbr_iisy15_r930/visual/base_link.stl"/>
@@ -31,6 +39,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.0489108039022503" ixy="0.0" ixz="0.0" iyy="0.0383705935400879" iyz="0.0" izz="0.0522121642769911"/>
+        <mass value="9.62E0"/>
+        <origin rpy="-1.3035636348359196 -0.7815781053554747 1.2529437882898196" xyz="0.00344301039501039 0.0191980353430353 -0.08662803846153849"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_lbr_iisy_support/meshes/lbr_iisy15_r930/visual/link_1.stl"/>
@@ -46,6 +59,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.0306168627253135" ixy="0.0" ixz="0.0" iyy="0.252047093745431" iyz="0.0" izz="0.258650362609461"/>
+        <mass value="8.079E0"/>
+        <origin rpy="-0.017400716172763755 1.2184236596039677E-4 7.609596915052352E-4" xyz="0.144939171927219 4.90834261666048E-4 -0.0453728741180839"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_lbr_iisy_support/meshes/lbr_iisy15_r930/visual/link_2.stl"/>
@@ -61,6 +79,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.0181557035426496" ixy="0.0" ixz="0.0" iyy="0.0346916391676837" iyz="0.0" izz="0.037776951242458"/>
+        <mass value="7.6604E0"/>
+        <origin rpy="0.1692981167548117 0.5271433699021747 -2.9605806714357508" xyz="0.0400709362435382 0.00400998642368544 0.0499127101717926"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_lbr_iisy_support/meshes/lbr_iisy15_r930/visual/link_3.stl"/>
@@ -76,6 +99,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.0208771593304277" ixy="0.0" ixz="0.0" iyy="0.0526135698207455" iyz="0.0" izz="0.0587485883681802"/>
+        <mass value="5.7014E0"/>
+        <origin rpy="1.535166999601284 -1.2065715961818437 -1.512863903166617" xyz="0.00141160065948714 0.060839292103693904 -0.12025970463395"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_lbr_iisy_support/meshes/lbr_iisy15_r930/visual/link_4.stl"/>
@@ -91,6 +119,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.00667288072123254" ixy="0.0" ixz="0.0" iyy="0.00503543168148481" iyz="0.0" izz="0.00841044585602456"/>
+        <mass value="2.382E0"/>
+        <origin rpy="0.4256203528755516 0.1454426479570896 1.2195648324165669" xyz="0.0365444794290512 -0.00829581863979849 -0.0371200125944584"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_lbr_iisy_support/meshes/lbr_iisy15_r930/visual/link_5.stl"/>
@@ -106,6 +139,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.00390274036654823" ixy="0.0" ixz="0.0" iyy="0.00286930887521153" iyz="0.0" izz="0.00403512413298348"/>
+        <mass value="1.509E0"/>
+        <origin rpy="-0.051936335875096745 -0.1296523529795729 -0.0038347791577379832" xyz="-5.61365142478463E-4 0.00904387011265739 -0.0494449237905898"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_lbr_iisy_support/meshes/lbr_iisy15_r930/visual/link_6.stl"/>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760.urdf.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760.urdf.xacro
@@ -6,7 +6,7 @@
   <xacro:arg name="prefix" default=""/>
   <xacro:arg name="controller_ip" default="0.0.0.0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
-  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="qos_config_file" default=""/>
   <xacro:arg name="x" default="0"/>
@@ -15,7 +15,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_lbr_iisy3_r760_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)" qos_config_file="$(arg qos_config_file)">
+  <xacro:kuka_lbr_iisy3_r760_robot prefix="$(arg prefix)" controller_ip="$(arg controller_ip)" client_ip="$(arg client_ip)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)" qos_config_file="$(arg qos_config_file)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_lbr_iisy3_r760_robot>
 </robot>

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760_macro.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy3_r760_macro.xacro
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="lbr_iisy3_r760">
   <!-- include helper xacros -->
+  <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_lbr_iisy_support)/urdf/lbr_iisy_transmission.xacro"/>
-  <xacro:macro name="kuka_lbr_iisy3_r760_robot" params="prefix controller_ip client_ip use_fake_hardware roundtrip_time qos_config_file *origin">
+  <xacro:macro name="kuka_lbr_iisy3_r760_robot" params="prefix controller_ip client_ip mode roundtrip_time qos_config_file *origin">
+    <!-- gazebo -->
+    <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml" />
     <!-- ros2 control instance -->
-    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy3_r760" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
+    <xacro:kuka_lbr_iisy_ros2_control name="${prefix}lbr_iisy3_r760" prefix="${prefix}" client_ip="${client_ip}" controller_ip="${controller_ip}" mode="${mode}" roundtrip_time="${roundtrip_time}" qos_config_file="${qos_config_file}"/>
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">
@@ -23,6 +26,11 @@
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
         <xacro:material_kuka_ral_pure_white/>
       </visual>
+      <inertial>
+        <inertia ixx="0.012748224322771616" ixy="0.0" ixz="0.0" iyy="0.010816256892101183" iyz="0.0" izz="0.014034253414070816"/>
+        <mass value="3.6832E0"/>
+        <origin rpy="-1.635646718734919 -1.5587113211406542 -3.076430534295977" xyz="-0.010469427580225498 2.2191996713941945E-18 0.06527114050303555"/>
+      </inertial>
     </link>
     <link name="${prefix}link_1">
       <collision>
@@ -38,6 +46,11 @@
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
         <xacro:material_kuka_ral_pure_white/>
       </visual>
+      <inertial>
+        <inertia ixx="0.00864540353780418" ixy="0.0" ixz="0.0" iyy="0.00573103463618732" iyz="0.0" izz="0.00974792600424334"/>
+        <mass value="3.2492E0"/>
+        <origin rpy="-1.5252872042613295 -0.9405332807925293 1.5213371149412753" xyz="-1.91677951495753E-4 0.024070491197833298 -0.0710631416964176"/>
+      </inertial>
     </link>
     <link name="${prefix}link_2">
       <collision>
@@ -53,6 +66,11 @@
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
         <xacro:material_kuka_ral_pure_white/>
       </visual>
+      <inertial>
+        <inertia ixx="0.0521692170047944" ixy="0.0" ixz="0.0" iyy="0.0042331111850977" iyz="0.0" izz="0.0534425693052013"/>
+        <mass value="3.212E0"/>
+        <origin rpy="9.692351535578106E-5 0.0015557646011294692 -1.5702311120941035" xyz="0.151061643835616 -6.75591531755915E-4 -0.034993673723536706"/>
+      </inertial>
     </link>
     <link name="${prefix}link_3">
       <collision>
@@ -68,6 +86,11 @@
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
         <xacro:material_kuka_ral_pure_white/>
       </visual>
+      <inertial>
+        <inertia ixx="0.0113804888378926" ixy="0.0" ixz="0.0" iyy="0.00566536942404497" iyz="0.0" izz="0.0133950588482047"/>
+        <mass value="3.471E0"/>
+        <origin rpy="1.5993955084701255 -1.1491769762279627 3.1012276608488882" xyz="0.029424678766926 2.54105445116681E-4 0.058670936329588"/>
+      </inertial>
     </link>
     <link name="${prefix}link_4">
       <collision>
@@ -83,6 +106,11 @@
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
         <xacro:material_kuka_ral_pure_white/>
       </visual>
+      <inertial>
+        <inertia ixx="0.00244684891934666" ixy="0.0" ixz="0.0" iyy="0.00929300990970133" iyz="0.0" izz="0.00957902612033654"/>
+        <mass value="2.0138E0"/>
+        <origin rpy="1.6613960972986936 -1.1557380835519457 -1.5702834955545293" xyz="1.05670870990168E-4 0.038203987486344196 -0.0813488578806237"/>
+      </inertial>
     </link>
     <link name="${prefix}link_5">
       <collision>
@@ -98,6 +126,11 @@
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
         <xacro:material_kuka_ral_pure_white/>
       </visual>
+      <inertial>
+        <inertia ixx="0.00236252846105637" ixy="0.0" ixz="0.0" iyy="0.00141854396142661" iyz="0.0" izz="0.0025813096143987"/>
+        <mass value="1.4418E0"/>
+        <origin rpy="-1.7233052822660835 -1.3466087566012612 0.1844343658550185" xyz="0.0223951033430434 -2.98134988556471E-21 -0.0316419475655431"/>
+      </inertial>
     </link>
     <link name="${prefix}link_6">
       <collision>
@@ -113,6 +146,11 @@
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
         <xacro:material_kuka_ral_pure_white/>
       </visual>
+      <inertial>
+        <inertia ixx="0.00130428196885741" ixy="0.0" ixz="0.0" iyy="8.59824496082689E-4" iyz="0.0" izz="0.00133168575299756"/>
+        <mass value="7.25E-1"/>
+        <origin rpy="-0.5546496285205927 -0.9838872221389914 0.47057095417629574" xyz="-8.78896551724138E-4 0.0100584827586207 -0.0396903310344828"/>
+      </inertial>
     </link>
     <!-- joints - main serial chain -->
     <joint name="${prefix}world-base_link" type="fixed">

--- a/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
+++ b/kuka_lbr_iisy_support/urdf/lbr_iisy_ros2_control.xacro
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_lbr_iisy_ros2_control" params="name prefix client_ip controller_ip use_fake_hardware qos_config_file roundtrip_time">
+  <xacro:macro name="kuka_lbr_iisy_ros2_control" params="name prefix client_ip controller_ip mode qos_config_file roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
-        <xacro:if value="${use_fake_hardware}">
+        <xacro:if value="${mode == 'mock'}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
           <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
-        <xacro:unless value="${use_fake_hardware}">
+        <xacro:unless value="${mode != 'hardware'}">
           <!-- Read QoS profile parameters  -->
           <xacro:if value="${qos_config_file == ''}">
             <xacro:property name="qos_config" value="$(find kuka_iiqka_eac_driver)/config/qos_config.yaml"/>
@@ -29,13 +29,18 @@
           <param name="lost_packets_in_timeframe">${lost_packets_in_timeframe}</param>
           <param name="timeframe_ms">${timeframe_ms}</param>
         </xacro:unless>
+        <xacro:if value="${mode == 'gazebo'}">
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+        </xacro:if>
       </hardware>
       <!-- define joints and command/state interfaces for each joint -->
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="stiffness"/>
+          <command_interface name="damping"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -45,9 +50,11 @@
       </joint>
       <joint name="${prefix}joint_2">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="stiffness"/>
+          <command_interface name="damping"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <param name="initial_value">-1.5708</param>
         </state_interface>
@@ -57,9 +64,11 @@
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="stiffness"/>
+          <command_interface name="damping"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <param name="initial_value">1.5708</param>
         </state_interface>
@@ -69,9 +78,11 @@
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="stiffness"/>
+          <command_interface name="damping"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -81,9 +92,11 @@
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="stiffness"/>
+          <command_interface name="damping"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>
@@ -93,9 +106,11 @@
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position"/>
-        <command_interface name="stiffness"/>
-        <command_interface name="damping"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="${mode == 'gazebo'}">
+          <command_interface name="stiffness"/>
+          <command_interface name="damping"/>
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>

--- a/kuka_quantec_support/CMakeLists.txt
+++ b/kuka_quantec_support/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(xacro REQUIRED)
 install(DIRECTORY config launch meshes urdf
   DESTINATION share/${PROJECT_NAME})
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.dsv")
+
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake)
   add_launch_test(test/test_kr_quantec.py)

--- a/kuka_quantec_support/kuka_quantec_support.dsv
+++ b/kuka_quantec_support/kuka_quantec_support.dsv
@@ -1,0 +1,1 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share

--- a/kuka_quantec_support/urdf/kr210_r2700_2.urdf.xacro
+++ b/kuka_quantec_support/urdf/kr210_r2700_2.urdf.xacro
@@ -3,7 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr210_r2700_2_macro.xacro"/>
   <!-- Read additional arguments  -->
-  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
@@ -14,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr210_r2700_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr210_r2700_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr210_r2700_2_robot>
 </robot>

--- a/kuka_quantec_support/urdf/kr210_r2700_2_macro.xacro
+++ b/kuka_quantec_support/urdf/kr210_r2700_2_macro.xacro
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr210_r2700_2_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
+  <xacro:macro name="kuka_kr210_r2700_2_robot" params="client_ip client_port prefix mode roundtrip_time *origin">
+    <!-- gazebo -->
+    <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml" />
     <!-- ros2 control instance -->
-    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r2700_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r2700_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>
@@ -13,6 +16,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="12.8309" ixy="0.0" ixz="0.0" iyy="9.012" iyz="0.0" izz="14.2959"/>
+        <mass value="2.2596E2"/>
+        <origin rpy="-0.050860639732366764 -0.0019879300180215415 1.5231488382154512" xyz="-0.0594893 0.0021560000000000004 0.2032507"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r2700_2/visual/base_link.stl"/>
@@ -27,6 +35,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="13.2088588047575" ixy="0.0" ixz="0.0" iyy="31.4949853249961" iyz="0.0" izz="33.8838908182464"/>
+        <mass value="3.6307E2"/>
+        <origin rpy="1.8661968490595335 0.10258164628689437 -0.21632411420056308" xyz="0.0287871760266615 0.011875249400942 -0.23402828104773202"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r2700_2/visual/link_1.stl"/>
@@ -41,6 +54,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="57.7957098112911" ixy="0.0" ixz="0.0" iyy="5.63272995683345" iyz="0.0" izz="58.559845591006"/>
+        <mass value="2.3206E2"/>
+        <origin rpy="-2.820395530490072 -1.218114484700482 1.2776348095029473" xyz="0.486870981642679 -0.00190295613203482 -0.11763677497199"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r2700_2/visual/link_2.stl"/>
@@ -55,6 +73,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="3.46995402943128" ixy="0.0" ixz="0.0" iyy="21.1713007283949" iyz="0.0" izz="22.2067749058774"/>
+        <mass value="1.9033E2"/>
+        <origin rpy="2.182263605188562 -0.06560775132626494 -0.05349640342552061" xyz="0.17377229023275398 -0.07596253874848949 0.136185412704251"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r2700_2/visual/link_3.stl"/>
@@ -69,6 +92,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.161324366141546" ixy="0.0" ixz="0.0" iyy="1.3645139545175" iyz="0.0" izz="1.39158127634524"/>
+        <mass value="4.2411794929E1"/>
+        <origin rpy="1.5711454552070345 -1.4368320268822927 -1.5712071247684845" xyz="-7.5764465140740704E-6 0.0192023882938968 -0.197888748752496"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r2700_2/visual/link_4.stl"/>
@@ -83,6 +111,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.200111908543801" ixy="0.0" ixz="0.0" iyy="0.120553626775201" iyz="0.0" izz="0.220956494925724"/>
+        <mass value="1.6991732133E1"/>
+        <origin rpy="1.5704759351872302 -0.8762558401259876 -0.0022796281329216955" xyz="0.062235569792816796 3.0314811620972E-4 -0.0657532427101687"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r2700_2/visual/link_5.stl"/>
@@ -97,6 +130,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.0114565" ixy="0.0" ixz="0.0" iyy="0.0114565" iyz="0.0" izz="0.014535"/>
+        <mass value="6.6E0"/>
+        <origin rpy="0.0 -0.0 0.0" xyz="0.0 0.0 -0.006500000000000001"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r2700_2/visual/link_6.stl"/>

--- a/kuka_quantec_support/urdf/kr210_r3100_2.urdf.xacro
+++ b/kuka_quantec_support/urdf/kr210_r3100_2.urdf.xacro
@@ -3,7 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr210_r3100_2_macro.xacro"/>
   <!-- Read additional arguments  -->
-  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
   <xacro:arg name="client_port" default="59152"/>
@@ -14,7 +14,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr210_r3100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" use_fake_hardware="$(arg use_fake_hardware)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr210_r3100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr210_r3100_2_robot>
 </robot>

--- a/kuka_quantec_support/urdf/kr210_r3100_2_macro.xacro
+++ b/kuka_quantec_support/urdf/kr210_r3100_2_macro.xacro
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr210_r3100_2_robot" params="client_ip client_port prefix use_fake_hardware roundtrip_time *origin">
+  <xacro:macro name="kuka_kr210_r3100_2_robot" params="client_ip client_port prefix mode roundtrip_time *origin">
+    <!-- gazebo -->
+    <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml" />
     <!-- ros2 control instance -->
-    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r3100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" use_fake_hardware="${use_fake_hardware}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r3100_2" client_ip="${client_ip}" client_port="${client_port}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>
@@ -13,6 +16,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="12.8308803908269" ixy="0.0" ixz="0.0" iyy="9.01196989503174" iyz="0.0" izz="14.2958860155811"/>
+        <mass value="2.2596E2"/>
+        <origin rpy="-0.050860131411839364 -0.0019883389878402632 1.5231487443995257" xyz="-0.0594893335103558 0.0021559506107275703 0.20325069304301702"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r3100_2/visual/base_link.stl"/>
@@ -27,6 +35,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="31.7863155713632" ixy="0.0" ixz="0.0" iyy="13.3310318632879" iyz="0.0" izz="34.1806723147254"/>
+        <mass value="3.6737E2"/>
+        <origin rpy="-0.351197441830708 -1.2748494702774995 -1.4514723788195059" xyz="0.0282630046002668 0.011134569507580901 -0.235336739526907"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r3100_2/visual/link_1.stl"/>
@@ -41,6 +54,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="6.11156632969732" ixy="0.0" ixz="0.0" iyy="82.7509302435823" iyz="0.0" izz="83.2585967164398"/>
+        <mass value="2.5056E2"/>
+        <origin rpy="0.5376277345260776 0.09067448308201614 0.007191247120022789" xyz="0.577871168582376 -0.0013846982758620701 -0.125571679438059"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r3100_2/visual/link_2.stl"/>
@@ -55,6 +73,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="3.682159161562" ixy="0.0" ixz="0.0" iyy="33.5342001702104" iyz="0.0" izz="34.5572935050498"/>
+        <mass value="2.0653E2"/>
+        <origin rpy="2.1573989163353855 -0.05591461513404206 -0.051760900676735326" xyz="0.245752626737036 -0.0785722655304314 0.139793974725222"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r3100_2/visual/link_3.stl"/>
@@ -69,6 +92,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.201148018312786" ixy="0.0" ixz="0.0" iyy="1.61560245160953" iyz="0.0" izz="1.64041744739939"/>
+        <mass value="4.7942845677E1"/>
+        <origin rpy="1.570992251106443 -1.3912820307912874 -1.5710550346492322" xyz="-8.82769985166503E-6 0.030038038468557102 -0.22035014882022402"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r3100_2/visual/link_4.stl"/>
@@ -83,6 +111,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.34306033744263" ixy="0.0" ixz="0.0" iyy="0.19689279813435" iyz="0.0" izz="0.347976409834227"/>
+        <mass value="2.3687644624E1"/>
+        <origin rpy="1.6224506086845345 -0.9319967320369543 -0.06488528019058366" xyz="0.062409087507207 2.1098685344562402E-4 -0.0640578845918283"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r3100_2/visual/link_5.stl"/>
@@ -97,6 +130,11 @@
         </geometry>
         <origin rpy="-0.0 0.0 -0.0" xyz="0.0 0.0 0.0"/>
       </collision>
+      <inertial>
+        <inertia ixx="0.0369411271609063" ixy="0.0" ixz="0.0" iyy="0.0369531532955219" iyz="0.0" izz="0.0482510013261814"/>
+        <mass value="1.2245718539E1"/>
+        <origin rpy="1.0758644105165322E-4 -9.812464461473523E-5 -0.03310542818383201" xyz="4.5958226185134805E-6 -5.59089459126197E-6 -0.0254361898182505"/>
+      </inertial>
       <visual>
         <geometry>
           <mesh filename="package://kuka_quantec_support/meshes/kr210_r3100_2/visual/link_6.stl"/>

--- a/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
+++ b/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_quantec_ros2_control" params="name client_ip client_port prefix use_fake_hardware roundtrip_time">
+  <xacro:macro name="kuka_quantec_ros2_control" params="name client_ip client_port prefix mode roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
-        <xacro:if value="${use_fake_hardware}">
+        <xacro:if value="${mode == 'mock'}">
           <plugin>kuka_mock_hardware_interface::KukaMockHardwareInterface</plugin>
           <param name="cycle_time_ms">4</param>
           <param name="roundtrip_time_micro">${roundtrip_time}</param>
           <param name="mock_sensor_commands">false</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
-        <xacro:unless value="${use_fake_hardware}">
+        <xacro:unless value="${mode != 'hardware'}">
           <plugin>kuka_kss_rsi_driver::KukaRSIHardwareInterface</plugin>
           <param name="client_ip">${client_ip}</param>
           <param name="client_port">${client_port}</param>
         </xacro:unless>
+        <xacro:if value="${mode == 'gazebo'}">
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+        </xacro:if>
       </hardware>
       <joint name="${prefix}joint_1">
         <command_interface name="position"/>


### PR DESCRIPTION
### Before submitting this PR into master please make sure:

If you modified an already existing robot model:
- [x] you checked and optionally updated the table of verified data in `README.md` with the changes
- [x] you have run the `test_<robot_model>.launch.py` and the robot was visible in `rviz`

### Short description of the change
- Added a third mode (gazebo) alongside hardware and hardware mock
- Updated the URDFs accordingly
- Added example where lbr iisy3 r760 robot moves a box in Gazebo simulation
- Added separate moveit launch files for Gazebo along with a Gazebo package to launch Gazebo.

**iiwa, cybertech, and kr6 r700 and r900 robots are missing inertial values, so Gazebo support is not provided for them.**