### PR TITLE
Add parameter for choosing the right driver version

### DIFF
--- a/kuka_agilus_support/urdf/kr10_r1100_2.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr10_r1100_2.urdf.xacro
@@ -3,6 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr10_r1100_2_macro.xacro"/>
   <!-- Read additional arguments  -->
+  <xacro:arg name="driver_version" default="rsi_only"/>
   <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
@@ -15,7 +16,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr10_r1100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr10_r1100_2_robot driver_version="$(arg driver_version)" client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr10_r1100_2_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr10_r1100_2_macro.xacro
+++ b/kuka_agilus_support/urdf/kr10_r1100_2_macro.xacro
@@ -4,14 +4,14 @@
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
-  <xacro:macro name="kuka_kr10_r1100_2_robot" params="client_ip client_port controller_ip prefix mode roundtrip_time *origin">
+  <xacro:macro name="kuka_kr10_r1100_2_robot" params="driver_version client_ip client_port controller_ip prefix mode roundtrip_time *origin">
     <!-- gazebo -->
     <xacro:if value="${mode == 'gazebo'}">
       <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
       <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml"/>
     </xacro:if>
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr10_r1100_2" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr10_r1100_2" driver_version="${driver_version}" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <!-- links - main serial chain -->
     <link name="world"/>
     <link name="${prefix}base_link">

--- a/kuka_agilus_support/urdf/kr6_r700_sixx.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr6_r700_sixx.urdf.xacro
@@ -3,6 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr6_r700_sixx_macro.xacro"/>
   <!-- Read additional arguments  -->
+  <xacro:arg name="driver_version" default="rsi_only"/>
   <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
@@ -15,7 +16,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr6_r700_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr6_r700_sixx_robot driver_version="$(arg driver_version)" client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr6_r700_sixx_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r700_sixx_macro.xacro
@@ -4,9 +4,9 @@
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
-  <xacro:macro name="kuka_kr6_r700_sixx_robot" params="client_ip client_port controller_ip prefix mode roundtrip_time *origin">
+  <xacro:macro name="kuka_kr6_r700_sixx_robot" params="driver_version client_ip client_port controller_ip prefix mode roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r700_sixx" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r700_sixx" driver_version="${driver_version}" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <visual>

--- a/kuka_agilus_support/urdf/kr6_r900_sixx.urdf.xacro
+++ b/kuka_agilus_support/urdf/kr6_r900_sixx.urdf.xacro
@@ -3,6 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr6_r900_sixx_macro.xacro"/>
   <!-- Read additional arguments  -->
+  <xacro:arg name="driver_version" default="rsi_only"/>
   <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
@@ -15,7 +16,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr6_r900_sixx_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr6_r900_sixx_robot driver_version="$(arg driver_version)" client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr6_r900_sixx_robot>
 </robot>

--- a/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
+++ b/kuka_agilus_support/urdf/kr6_r900_sixx_macro.xacro
@@ -4,9 +4,9 @@
   <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_agilus_support)/urdf/kr_agilus_transmission.xacro"/>
-  <xacro:macro name="kuka_kr6_r900_sixx_robot" params="client_ip client_port controller_ip prefix mode roundtrip_time *origin">
+  <xacro:macro name="kuka_kr6_r900_sixx_robot" params="driver_version client_ip client_port controller_ip prefix mode roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r900_sixx" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_agilus_ros2_control name="${prefix}kr6_r900_sixx" driver_version="${driver_version}" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <visual>

--- a/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
+++ b/kuka_agilus_support/urdf/kr_agilus_ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_agilus_ros2_control" params="name client_ip client_port controller_ip prefix mode roundtrip_time">
+  <xacro:macro name="kuka_agilus_ros2_control" params="name driver_version client_ip client_port controller_ip prefix mode roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${mode == 'mock'}">
@@ -11,10 +11,14 @@
           <param name="state_following_offset">0.0</param>
         </xacro:if>
         <xacro:if value="${mode == 'hardware'}">
-          <plugin>kuka_rsi_driver::KukaRSIHardwareInterface</plugin>
-          <param name="client_ip">${client_ip}</param>
-          <param name="client_port">${client_port}</param>
-          <param name="controller_ip">${controller_ip}</param>
+          <xacro:if value="${driver_version == 'eki_rsi'}">
+            <plugin>kuka_rsi_driver::KukaEkiRsiHardwareInterface</plugin>
+            <param name="controller_ip">${controller_ip}</param>
+            <param name="name">${name}</param>
+          </xacro:if>
+          <xacro:if value="${driver_version == 'rsi_only'}">
+            <plugin>kuka_rsi_driver::KukaRSIHardwareInterface</plugin>
+          </xacro:if>
         </xacro:if>
         <xacro:if value="${mode == 'gazebo'}">
           <plugin>gz_ros2_control/GazeboSimSystem</plugin>

--- a/kuka_cybertech_support/urdf/kr16_r2010_2.urdf.xacro
+++ b/kuka_cybertech_support/urdf/kr16_r2010_2.urdf.xacro
@@ -3,6 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_cybertech_support)/urdf/kr16_r2010_2_macro.xacro"/>
   <!-- Read additional arguments  -->
+  <xacro:arg name="driver_version" default="eki_rsi"/>
   <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
@@ -15,7 +16,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr16_r2010_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr16_r2010_2_robot driver_version="$(arg driver_version)" client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr16_r2010_2_robot>
 </robot>

--- a/kuka_cybertech_support/urdf/kr16_r2010_2_macro.xacro
+++ b/kuka_cybertech_support/urdf/kr16_r2010_2_macro.xacro
@@ -2,9 +2,9 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find kuka_cybertech_support)/urdf/kr_cybertech_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_cybertech_support)/urdf/kr_cybertech_transmission.xacro"/>
-  <xacro:macro name="kuka_kr16_r2010_2_robot" params="client_ip client_port controller_ip prefix mode roundtrip_time *origin">
+  <xacro:macro name="kuka_kr16_r2010_2_robot" params="driver_version client_ip client_port controller_ip prefix mode roundtrip_time *origin">
     <!-- ros2 control instance -->
-    <xacro:kuka_cybertech_ros2_control name="${prefix}kr16_r2010_2" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_cybertech_ros2_control name="${prefix}kr16_r2010_2" driver_version="${driver_version}" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>

--- a/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
+++ b/kuka_cybertech_support/urdf/kr_cybertech_ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_cybertech_ros2_control" params="name client_ip client_port controller_ip prefix mode roundtrip_time">
+  <xacro:macro name="kuka_cybertech_ros2_control" params="name driver_version client_ip client_port controller_ip prefix mode roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${mode == 'mock'}">
@@ -11,10 +11,14 @@
           <param name="state_following_offset">0.0</param>
         </xacro:if>
         <xacro:if value="${mode == 'hardware'}">
-          <plugin>kuka_rsi_driver::KukaRSIHardwareInterface</plugin>
-          <param name="client_ip">${client_ip}</param>
-          <param name="client_port">${client_port}</param>
-          <param name="controller_ip">${controller_ip}</param>
+          <xacro:if value="${driver_version == 'eki_rsi'}">
+            <plugin>kuka_rsi_driver::KukaEkiRsiHardwareInterface</plugin>
+            <param name="controller_ip">${controller_ip}</param>
+            <param name="name">${name}</param>
+          </xacro:if>
+          <xacro:if value="${driver_version == 'rsi_only'}">
+            <plugin>kuka_rsi_driver::KukaRSIHardwareInterface</plugin>
+          </xacro:if>
         </xacro:if>
         <xacro:if value="${mode == 'gazebo'}">
           <plugin>gz_ros2_control/GazeboSimSystem</plugin>

--- a/kuka_fortec_support/urdf/kr560_r3100_2.urdf.xacro
+++ b/kuka_fortec_support/urdf/kr560_r3100_2.urdf.xacro
@@ -3,6 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_fortec_support)/urdf/kr560_r3100_2_macro.xacro"/>
   <!-- Read additional arguments  -->
+  <xacro:arg name="driver_version" default="rsi_only"/>
   <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
@@ -15,7 +16,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr560_r3100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr560_r3100_2_robot driver_version="$(arg driver_version)" client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr560_r3100_2_robot>
 </robot>

--- a/kuka_fortec_support/urdf/kr560_r3100_2_macro.xacro
+++ b/kuka_fortec_support/urdf/kr560_r3100_2_macro.xacro
@@ -2,14 +2,14 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find kuka_fortec_support)/urdf/kr_fortec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_fortec_support)/urdf/kr_fortec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr560_r3100_2_robot" params="client_ip client_port controller_ip prefix mode roundtrip_time *origin">
+  <xacro:macro name="kuka_kr560_r3100_2_robot" params="driver_version client_ip client_port controller_ip prefix mode roundtrip_time *origin">
     <!-- gazebo -->
     <xacro:if value="${mode == 'gazebo'}">
       <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
       <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml"/>
     </xacro:if>
     <!-- ros2 control instance -->
-    <xacro:kuka_fortec_ros2_control name="${prefix}kr560_r3100_2" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_fortec_ros2_control name="${prefix}kr560_r3100_2" driver_version="${driver_version}" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>

--- a/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
+++ b/kuka_fortec_support/urdf/kr_fortec_ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_fortec_ros2_control" params="name client_ip client_port controller_ip prefix mode roundtrip_time">
+  <xacro:macro name="kuka_fortec_ros2_control" params="name driver_version client_ip client_port controller_ip prefix mode roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${mode == 'mock'}">
@@ -11,10 +11,14 @@
           <param name="state_following_offset">0.0</param>
         </xacro:if>
         <xacro:if value="${mode == 'hardware'}">
-          <plugin>kuka_rsi_driver::KukaRSIHardwareInterface</plugin>
-          <param name="client_ip">${client_ip}</param>
-          <param name="client_port">${client_port}</param>
-          <param name="controller_ip">${controller_ip}</param>
+          <xacro:if value="${driver_version == 'eki_rsi'}">
+            <plugin>kuka_rsi_driver::KukaEkiRsiHardwareInterface</plugin>
+            <param name="controller_ip">${controller_ip}</param>
+            <param name="name">${name}</param>
+          </xacro:if>
+          <xacro:if value="${driver_version == 'rsi_only'}">
+            <plugin>kuka_rsi_driver::KukaRSIHardwareInterface</plugin>
+          </xacro:if>
         </xacro:if>
         <xacro:if value="${mode == 'gazebo'}">
           <plugin>gz_ros2_control/GazeboSimSystem</plugin>

--- a/kuka_iontec_support/urdf/kr70_r2100.urdf.xacro
+++ b/kuka_iontec_support/urdf/kr70_r2100.urdf.xacro
@@ -3,6 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_iontec_support)/urdf/kr70_r2100_macro.xacro"/>
   <!-- Read additional arguments  -->
+  <xacro:arg name="driver_version" default="rsi_only"/>
   <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
@@ -15,7 +16,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr70_r2100_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr70_r2100_robot driver_version="$(arg driver_version)" client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr70_r2100_robot>
 </robot>

--- a/kuka_iontec_support/urdf/kr70_r2100_macro.xacro
+++ b/kuka_iontec_support/urdf/kr70_r2100_macro.xacro
@@ -2,14 +2,14 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find kuka_iontec_support)/urdf/kr_iontec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_iontec_support)/urdf/kr_iontec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr70_r2100_robot" params="client_ip client_port controller_ip prefix mode roundtrip_time *origin">
+  <xacro:macro name="kuka_kr70_r2100_robot" params="driver_version client_ip client_port controller_ip prefix mode roundtrip_time *origin">
     <!-- gazebo -->
     <xacro:if value="${mode == 'gazebo'}">
       <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
       <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml"/>
     </xacro:if>
     <!-- ros2 control instance -->
-    <xacro:kuka_iontec_ros2_control name="${prefix}kr70_r2100" client_ip="${client_ip}" controller_ip="${controller_ip}" client_port="${client_port}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_iontec_ros2_control name="${prefix}kr70_r2100" driver_version="${driver_version}" client_ip="${client_ip}" controller_ip="${controller_ip}" client_port="${client_port}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>

--- a/kuka_iontec_support/urdf/kr_iontec_ros2_control.xacro
+++ b/kuka_iontec_support/urdf/kr_iontec_ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_iontec_ros2_control" params="name client_ip client_port controller_ip prefix mode roundtrip_time">
+  <xacro:macro name="kuka_iontec_ros2_control" params="name driver_version client_ip client_port controller_ip prefix mode roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${mode == 'mock'}">
@@ -11,10 +11,14 @@
           <param name="state_following_offset">0.0</param>
         </xacro:if>
         <xacro:if value="${mode == 'hardware'}">
-          <plugin>kuka_rsi_driver::KukaRSIHardwareInterface</plugin>
-          <param name="client_ip">${client_ip}</param>
-          <param name="client_port">${client_port}</param>
-          <param name="controller_ip">${controller_ip}</param>
+          <xacro:if value="${driver_version == 'eki_rsi'}">
+            <plugin>kuka_rsi_driver::KukaEkiRsiHardwareInterface</plugin>
+            <param name="controller_ip">${controller_ip}</param>
+            <param name="name">${name}</param>
+          </xacro:if>
+          <xacro:if value="${driver_version == 'rsi_only'}">
+            <plugin>kuka_rsi_driver::KukaRSIHardwareInterface</plugin>
+          </xacro:if>
         </xacro:if>
         <xacro:if value="${mode == 'gazebo'}">
           <plugin>gz_ros2_control/GazeboSimSystem</plugin>

--- a/kuka_quantec_support/urdf/kr150_r3100_2.urdf.xacro
+++ b/kuka_quantec_support/urdf/kr150_r3100_2.urdf.xacro
@@ -3,6 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr150_r3100_2_macro.xacro"/>
   <!-- Read additional arguments  -->
+  <xacro:arg name="driver_version" default="rsi_only"/>
   <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
@@ -15,7 +16,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr150_r3100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr150_r3100_2_robot driver_version="$(arg driver_version)" client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr150_r3100_2_robot>
 </robot>

--- a/kuka_quantec_support/urdf/kr150_r3100_2_macro.xacro
+++ b/kuka_quantec_support/urdf/kr150_r3100_2_macro.xacro
@@ -2,14 +2,14 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr150_r3100_2_robot" params="client_ip client_port controller_ip prefix mode roundtrip_time *origin">
+  <xacro:macro name="kuka_kr150_r3100_2_robot" params="driver_version client_ip client_port controller_ip prefix mode roundtrip_time *origin">
     <!-- gazebo -->
     <xacro:if value="${mode == 'gazebo'}">
       <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
       <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml"/>
     </xacro:if>
     <!-- ros2 control instance -->
-    <xacro:kuka_quantec_ros2_control name="${prefix}kr150_r3100_2" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_quantec_ros2_control name="${prefix}kr150_r3100_2" driver_version="${driver_version}" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>

--- a/kuka_quantec_support/urdf/kr210_r2700_2.urdf.xacro
+++ b/kuka_quantec_support/urdf/kr210_r2700_2.urdf.xacro
@@ -3,6 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr210_r2700_2_macro.xacro"/>
   <!-- Read additional arguments  -->
+  <xacro:arg name="driver_version" default="rsi_only"/>
   <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
@@ -15,7 +16,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr210_r2700_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr210_r2700_2_robot driver_version="$(arg driver_version)" client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr210_r2700_2_robot>
 </robot>

--- a/kuka_quantec_support/urdf/kr210_r2700_2_macro.xacro
+++ b/kuka_quantec_support/urdf/kr210_r2700_2_macro.xacro
@@ -2,14 +2,14 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr210_r2700_2_robot" params="client_ip client_port controller_ip prefix mode roundtrip_time *origin">
+  <xacro:macro name="kuka_kr210_r2700_2_robot" params="driver_version client_ip client_port controller_ip prefix mode roundtrip_time *origin">
     <!-- gazebo -->
     <xacro:if value="${mode == 'gazebo'}">
       <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
       <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml"/>
     </xacro:if>
     <!-- ros2 control instance -->
-    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r2700_2" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r2700_2" driver_version="${driver_version}" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>

--- a/kuka_quantec_support/urdf/kr210_r3100_2.urdf.xacro
+++ b/kuka_quantec_support/urdf/kr210_r3100_2.urdf.xacro
@@ -3,6 +3,7 @@
   <!-- Import urdf file  -->
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr210_r3100_2_macro.xacro"/>
   <!-- Read additional arguments  -->
+  <xacro:arg name="driver_version" default="rsi_only"/>
   <xacro:arg name="mode" default="hardware"/>
   <xacro:arg name="roundtrip_time" default="0"/>
   <xacro:arg name="client_ip" default="0.0.0.0"/>
@@ -15,7 +16,7 @@
   <xacro:arg name="roll" default="0"/>
   <xacro:arg name="pitch" default="0"/>
   <xacro:arg name="yaw" default="0"/>
-  <xacro:kuka_kr210_r3100_2_robot client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
+  <xacro:kuka_kr210_r3100_2_robot driver_version="$(arg driver_version)" client_ip="$(arg client_ip)" client_port="$(arg client_port)" controller_ip="$(arg controller_ip)" prefix="$(arg prefix)" mode="$(arg mode)" roundtrip_time="$(arg roundtrip_time)">
     <origin xyz="$(arg x) $(arg y) $(arg z)" rpy="$(arg roll) $(arg pitch) $(arg yaw)"/>
   </xacro:kuka_kr210_r3100_2_robot>
 </robot>

--- a/kuka_quantec_support/urdf/kr210_r3100_2_macro.xacro
+++ b/kuka_quantec_support/urdf/kr210_r3100_2_macro.xacro
@@ -2,14 +2,14 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_ros2_control.xacro"/>
   <xacro:include filename="$(find kuka_quantec_support)/urdf/kr_quantec_transmission.xacro"/>
-  <xacro:macro name="kuka_kr210_r3100_2_robot" params="client_ip client_port controller_ip prefix mode roundtrip_time *origin">
+  <xacro:macro name="kuka_kr210_r3100_2_robot" params="driver_version client_ip client_port controller_ip prefix mode roundtrip_time *origin">
     <!-- gazebo -->
     <xacro:if value="${mode == 'gazebo'}">
       <xacro:include filename="$(find kuka_gazebo)/gazebo/kuka_gazebo.xacro"/>
       <xacro:kuka_gazebo controller_config_package="kuka_resources" controller_config_path="config/fake_hardware_config_6_axis.yaml"/>
     </xacro:if>
     <!-- ros2 control instance -->
-    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r3100_2" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
+    <xacro:kuka_quantec_ros2_control name="${prefix}kr210_r3100_2" driver_version="${driver_version}" client_ip="${client_ip}" client_port="${client_port}" controller_ip="${controller_ip}" prefix="${prefix}" mode="${mode}" roundtrip_time="${roundtrip_time}"/>
     <link name="world"/>
     <link name="${prefix}base_link">
       <collision>

--- a/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
+++ b/kuka_quantec_support/urdf/kr_quantec_ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="kuka_quantec_ros2_control" params="name client_ip client_port controller_ip prefix mode roundtrip_time">
+  <xacro:macro name="kuka_quantec_ros2_control" params="name driver_version client_ip client_port controller_ip prefix mode roundtrip_time">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${mode == 'mock'}">
@@ -11,10 +11,14 @@
           <param name="state_following_offset">0.0</param>
         </xacro:if>
         <xacro:if value="${mode == 'hardware'}">
-          <plugin>kuka_rsi_driver::KukaRSIHardwareInterface</plugin>
-          <param name="client_ip">${client_ip}</param>
-          <param name="client_port">${client_port}</param>
-          <param name="controller_ip">${controller_ip}</param>
+          <xacro:if value="${driver_version == 'eki_rsi'}">
+            <plugin>kuka_rsi_driver::KukaEkiRsiHardwareInterface</plugin>
+            <param name="controller_ip">${controller_ip}</param>
+            <param name="name">${name}</param>
+          </xacro:if>
+          <xacro:if value="${driver_version == 'rsi_only'}">
+            <plugin>kuka_rsi_driver::KukaRSIHardwareInterface</plugin>
+          </xacro:if>
         </xacro:if>
         <xacro:if value="${mode == 'gazebo'}">
           <plugin>gz_ros2_control/GazeboSimSystem</plugin>


### PR DESCRIPTION
### Before submitting this PR into master please make sure:

If you **modified** an already existing robot model:
- [x] you checked and optionally updated the table of verified data in `README.md` with the changes
- [x] you have run the `test_<robot_model>.launch.py` and the robot was visible in `rviz`

### Short description of the change

Added a parameter to all KSS robots so the driver version can be chosen when launching the driver, instead of needing to set it during compile time.
